### PR TITLE
admin_manual: add overwrite configuration documentation

### DIFF
--- a/admin_manual/configuration/configuration_overwrite.rst
+++ b/admin_manual/configuration/configuration_overwrite.rst
@@ -1,0 +1,26 @@
+Overwrite Configuration
+=======================
+
+The automatic hostname, protocol or webroot detection of ownCloud can fail in certain reverse proxy situations. This configuration allows to manually override the automatic detection.
+
+Parameters
+----------
+
+If ownCloud fails to automatically detected the hostname, protocol or webroot you can use the **overwrite** parameters inside the :file:`config/config.php`. The **overwritehost** parameter is used to set the hostname of the proxy. You can also specify a port. The **overwriteprotocol** parameter is used to set the protocol of the proxy. You can choose between the two options **http** and **https**. The **overwritewebroot** parameter is used to set the absolute web path of the proxy to the ownCloud folder. When you want to keep the automatic detection of one of the three parameters you can leave the value empty or don't set it. The **overwritecondaddr** parameter is used to overwrite the values dependent on the remote address. The value must be a **regular expression** of the IP addresses of the proxy. This is useful when you use a reverse SSL proxy only for https access and you want to use the automatic detection for http access. 
+
+Example
+-------
+
+Multiple Domains Reverse SSL Proxy
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If you want to access your ownCloud installation **http://domain.tld/owncloud** via a multiple domains reverse SSL proxy **https://ssl-proxy.tld/domain.tld/owncloud** with the IP address **10.0.0.1** you can set the following parameters inside the :file:`config/config.php`.
+
+.. code-block:: php
+
+  <?php
+
+    "overwritehost"     => "ssl-proxy.tld",
+    "overwriteprotocol" => "https",
+    "overwritewebroot"  => "/domain.tld/owncloud",
+    "overwritecondaddr" => "^10\.0\.0\.1$",

--- a/admin_manual/configuration/index.rst
+++ b/admin_manual/configuration/index.rst
@@ -12,6 +12,7 @@ Configuration
    configuration_knowledgebase
    configuration_logging
    configuration_mail
+   configuration_overwrite
    custom_mount_config
    custom_user_backend
    auth_ldap

--- a/admin_manual/index.rst
+++ b/admin_manual/index.rst
@@ -59,6 +59,7 @@ This chapter covers ownCloud and Webserver configuration.
 * :doc:`configuration/configuration_knowledgebase`
 * :doc:`configuration/configuration_logging`
 * :doc:`configuration/configuration_mail`
+* :doc:`configuration/configuration_overwrite`
 * :doc:`configuration/custom_mount_config`
 * :doc:`configuration/custom_user_backend`
 * :doc:`configuration/auth_ldap`


### PR DESCRIPTION
Add documentation for the overwrite functionality. Maybe the topic name should be change to reverse proxy but we have to make sure to not introduce confusion with the proxy configuration.
