### PR TITLE
Unify coding standards

### DIFF
--- a/developer_manual/general/codingguidelines.rst
+++ b/developer_manual/general/codingguidelines.rst
@@ -109,7 +109,6 @@ Control Structures
 * Always use { } for one line ifs
 * Split long ifs into multiple lines
 * Always use break in switch statements and prevent a default block with warnings if it shouldn't be accessed
-* Do not put spaces between variable and assignments in for loops
 
 .. code-block:: php
 
@@ -131,7 +130,7 @@ Control Structures
   }
 
   // for loop
-  for ($i=0; $i<4; $i++) {
+  for ($i = 0; $i < 4; $i++) {
       // your code
   }
 
@@ -282,7 +281,6 @@ Control Structures
 * Always use { } for one line ifs
 * Split long ifs into multiple lines
 * Always use break in switch statements and prevent a default block with warnings if it shouldn't be accessed
-* Do not put spaces between variable and assignments in for loops
 
 **DO**:
 
@@ -304,7 +302,7 @@ Control Structures
   }
 
   // for loop
-  for (var i=0; i<4; i++) {
+  for (var i = 0; i < 4; i++) {
       // your code
   }
 


### PR DESCRIPTION
The current coding standards are not consistent and are different to the old version http://owncloud.org/dev/coding-style-guide/. This pull request tries to unify them as most as possible with the PEAR Coding Standards except the use of tabs for indention and the use of opening braces on the same line.

This pull request is a suggestion and should only be applied after broad agreement.
