### PR TITLE
Protocol section of URL in KDE/Dolphin is actually webdav://, not just dav://

### DIFF
--- a/user_manual/files/files.rst
+++ b/user_manual/files/files.rst
@@ -22,7 +22,7 @@ KDE/Dolphin
 ~~~~~~~~~~~
 Click in the adress area and enter::
 
-    dav://youraddress.com/files/webdav.php
+    webdav://youraddress.com/files/webdav.php
 
 .. image:: ../images/dolphin_webdav.png
 


### PR DESCRIPTION
Protocol for (KIO-slave, I assume) in KDE/Dolphin is actually webdav://, not just dav://
