### PR TITLE
Require oC5 and not 6 to avoid compatibility error

### DIFF
--- a/developer_manual/app/intro/createapp.rst
+++ b/developer_manual/app/intro/createapp.rst
@@ -50,7 +50,7 @@ ownCloud has to know what your app is. This information is located inside the :f
       <version>1.0</version>
       <licence>AGPL</licence>
       <author>Your Name</author>
-      <require>6</require>
+      <require>5</require>
   </info>
 
 For more information on the content of :file:`appinfo/info.xml` see: :doc:`../app/info`


### PR DESCRIPTION
Changing <require>6</require> to <require>5</require>. "6" causes ownCloud to refuse to enable the app, because it thinks the app isn't compatible with the current version of oC.
