### PR TITLE
Enhance lighttpd doc: enable fastcgi check-local

### DIFF
--- a/admin_manual/installation/installation_others.rst
+++ b/admin_manual/installation/installation_others.rst
@@ -112,6 +112,17 @@ Disable directory listing::
          dir-listing.activate = "disable"
        }
 
+.. note:: The **check-local** option of lighttpd's fastcgi_  must be enabled.
+          It is sometimes disabled for security reasons. For example, 
+          the PHP process can run as a different user than lighttpd. 
+          Then, lighttpd might not be able to read/check the PHP files 
+          which the PHP process is able to read. Disabling 
+          **check-local** results in an incorrect **PATH_INFO** 
+          in PHP which produces a strange behavior of owncloud (such as 
+          incompletely loaded pages).
+
+.. _fastcgi: http://redmine.lighttpd.net/projects/1/wiki/Docs_ModFastCGI
+
 Yaws Configuration
 ------------------
 


### PR DESCRIPTION
Uh, this issue kept me busy for hours. My lighttpd installation had the `check-local` option of [fastcgi](http://redmine.lighttpd.net/projects/1/wiki/Docs_ModFastCGI) disabled because the PHP processes are run as different users for security reasons (a separate user for each virtual host). However, owncloud uses URLs like `/owncloud/index.php/apps/calendar/js/l10n.php` such that lighttpd takes the full URL as the file to be run (which does not exist). PHP seems to try to fix this and runs `/owncloud/index.php`, but then `PATH_INFO` is empty (it should be `/apps/calendar/js/l10n.php`). owncloud then behaves strangely because all kinds of AJAX calls fail (silently). For example, the configuration cannot be saved.

With `check-local` enabled, lighttpd is able to determine the correct file and sets `PATH_INFO` properly. I hope that this hint in the documentation will save other admins from some hours of unproductive work. ;)
