### PR TITLE
Correct fstab entry

### DIFF
--- a/user_manual/files/files.rst
+++ b/user_manual/files/files.rst
@@ -59,7 +59,7 @@ Mounting from command line
 
 4. Edit :file:`/etc/fstab` and add the following line for each user who wants to mount the folder (with your details where appropriate)::
 
-        youradress.com/files/webdav.php /home/<username>/owncloud davfs user,rw,noauto 0 0**.
+        youradress.com/files/webdav.php /home/<username>/owncloud davfs user,rw,noauto 0 0
 
 Then, as each user who wants to mount the folder:
 


### PR DESCRIPTION
It appears that the example fstab entry had unnecessary `**.` at the end.
I'm fairly ignorant when it comes to this stuff but I can't find any examples of those characters being necessary for the fsck option and mount fails with error:  

`[mntent]: line X in /etc/fstab is bad`

when that's there.
