### PR TITLE
Add LigHTTPd section to X-Sendfile documentation

### DIFF
--- a/admin_manual/configuration/xsendfile.rst
+++ b/admin_manual/configuration/xsendfile.rst
@@ -4,7 +4,7 @@ Since ownCloud 5 it is possible to let web servers handle static file serving.
 This should generally improve performance (web servers are optimized for this) and in some cases permits controlled file serving (i.e. pause
 and resume downloads).
 
-.. note :: This feature can currently only be activated for local files, i.e. files inside the **data/** directory and local mounts. Controlled file serving **does not work for generated zip files**. This is due to how temporary files are created. Also it has **never been tested under lighttpd** but its configuration should be the same as Apache
+.. note :: This feature can currently only be activated for local files, i.e. files inside the **data/** directory and local mounts. Controlled file serving **does not work for generated zip files**. This is due to how temporary files are created.
 
 Apache2 (X-Sendfile)
 --------------------
@@ -49,6 +49,30 @@ For versions >=0.10 (e.g. Ubuntu 12.10)
 * **XSendFile**: enables web server handling of X-Sendfile headers (and therefore file serving) for the specified Directory
 * **XSendFileAllowAbove (<0.10)**: enables file serving through web server on path outside the specified Directory. This is needed for PHP temporary directory where zip files are created and for configured local mounts which may reside outside data directory
 * **XSendFilePath (>=0.10)**: a white list of paths that the web server is allowed to serve outside of the specified Directory. At least PHP temporary directory concatenated with *oc-noclean* must be configured. Temporary zip files will be created inside this directory when using mod_xsendfile. Other paths which correspond to local mounts should be configured here aswell. For a more in-dept documentation of this directive refer to mod_xsendfile website linked above
+
+
+LigHTTPd (X-Sendfile2)
+----------------------
+LigHTTPd uses similar headers to Apache2, apart from the fact that it does not handle partial downloads in the same way Apache2 does. For this reason, a different method is used for LigHTTPd.
+
+Installation
+~~~~~~~~~~~~
+X-Sendfile and X-Sendfile2 are supported by default in LigHTTPd and no additional operation should be needed to install it.
+
+Configuration
+~~~~~~~~~~~~~
+Your server configuration should include the following statements::
+
+      fastcgi.server          = ( ".php" => ((
+         ...
+         "allow-x-send-file" => "enable",
+         "bin-environment" => (
+            "MOD_X_SENDFILE2_ENABLED" => "1",
+         ),
+      )))
+
+* **allow-x-send-file**: enables LigHTTPd to use X-Sendfile and X-Sendfile2 headers to serve files
+* **bin-environment**: is used to parse MOD_X_SENDFILE2_ENABLED to the ownCloud backend, to make it use the X-Sendfile and X-Sendfile2 headers in it's response
 
 
 Nginx (X-Accel-Redirect)


### PR DESCRIPTION
Added LigHTTPd section to reflect changes in core PR #3787

See also: https://github.com/owncloud/core/pull/3787
