### PR TITLE
added a short section "Set up your database and database user"

### DIFF
--- a/admin_manual/installation/installation_source.rst
+++ b/admin_manual/installation/installation_source.rst
@@ -108,6 +108,12 @@ For systemd systems (fedora, ArchLinux, Fedora, OpenSuse) use::
 
 In order for the maximum upload size to be configurable, the .htaccess file in the ownCloud folder needs to be made writable by the server.
 
+
+Set up your database and database user
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+A separate chapter explains how to set up the owncloud database and database user:
+* :doc:`/admin_manual/configuration/configuration_database`
+
 Follow the Install Wizard
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 Open your web browser and navigate to your ownCloud instance. If you are


### PR DESCRIPTION
added a short section "Set up your database and database user". I don't know, if the new link to 
- :doc:`/admin_manual/configuration/configuration_database

is well-formed for your system and layout. I did m very best. Pls. correct, if it is wrong, but such a section should be present here.
