### PR TITLE
adding a section databases in the installation chapter

### DIFF
--- a/admin_manual/configuration/configuration_database.rst
+++ b/admin_manual/configuration/configuration_database.rst
@@ -52,7 +52,7 @@ when you login for the first time.
 
 To start the MySQL command line mode use::
 
-  mysql -uroot -p
+  mysql -u root -p
 
 Then a **mysql>** or **MariaDB [root]>** prompt will appear. Now enter the following lines and confirm them with the enter key:
 

--- a/admin_manual/installation/installation_source.rst
+++ b/admin_manual/installation/installation_source.rst
@@ -108,6 +108,25 @@ For systemd systems (fedora, ArchLinux, Fedora, OpenSuse) use::
 
 In order for the maximum upload size to be configurable, the .htaccess file in the ownCloud folder needs to be made writable by the server.
 
+
+Set up your database and database user
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+A separate chapter explains how to set up the owncloud database and database user for various database systems:
+
+* :doc:`../configuration/configuration_database`
+
+When you use MySQL or MariaDB, you can create a new database "owncloud" and a new user "ownclouduser" with these lines:
+
+.. code-block:: sql
+
+  shell> mysql -u root -p
+  mysql> CREATE USER 'ownclouduser'@'localhost' IDENTIFIED BY 'password';
+         CREATE DATABASE IF NOT EXISTS owncloud;
+         GRANT ALL PRIVILEGES ON owncloud.* TO 'ownclouduser'@'localhost' IDENTIFIED BY 'password';
+         FLUSH PRIVILEGES;
+         EXIT;
+
+
 Follow the Install Wizard
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 Open your web browser and navigate to your ownCloud instance. If you are


### PR DESCRIPTION
Tested: The generated documentation looks okay to me. Perhaps we should harmonise the names of the database user -- I use "ownclouduser" to make clear, what it is.

As stated; perhaps it should be harmonised in the whole manual. Pls. let me know.
