### PR TITLE
Fixed lighttpd configuration

### DIFF
--- a/admin_manual/installation/installation_others.rst
+++ b/admin_manual/installation/installation_others.rst
@@ -109,13 +109,13 @@ It is important to note that the **.htaccess** files used by ownCloud to protect
 
 Disable access to data folder::
 
-    $HTTP["url"] =^ "^/owncloud/data/" {
+    $HTTP["url"] =~ "^/owncloud/data/" {
          url.access-deny = ("")
        }
 
 Disable directory listing::
 
-    $HTTP["url"] =^ "^/owncloud($|/)" {
+    $HTTP["url"] =~ "^/owncloud($|/)" {
          dir-listing.activate = "disable"
        }
 


### PR DESCRIPTION
The lighttpd configuration was broken, =^ is invalid syntax.
This fixes issue #63
