### PR TITLE
Fixing Apache 2.4 example config

### DIFF
--- a/admin_manual/installation/installation_source.rst
+++ b/admin_manual/installation/installation_source.rst
@@ -130,7 +130,6 @@ Example Apache 2.4:
     <Directory /path/to/your/owncloud/install>
         Options Indexes FollowSymLinks MultiViews
         AllowOverride All
-        Order allow,deny
         Require all granted
     </Directory>
 


### PR DESCRIPTION
Using the config before my commit (including "Order allow,deny") my apache (2.4.6) always showed an 403-Error on any OC page.
Don't know exactly why that line is bad, but Apache also recommends it this way. (http://httpd.apache.org/docs/2.4/upgrading.html#run-time)

And it works :)
