### PR TITLE
Add instructions on backporting HTTP PATCH support to Debian stable's Lighttpd

### DIFF
--- a/admin_manual/installation/installation_others.rst
+++ b/admin_manual/installation/installation_others.rst
@@ -143,8 +143,6 @@ Patch the package source::
 Increment the package version with ``dch -i``. This will open the changelog with a new entry. You can save as-is or add info to it. The important bit is that the version is bumped so apt will not try to "upgrade" back to Debian's version.
 
 Then build with ``debuild`` and install the .debs for any Lighttpd packages you already have installed.
-    
-
 
 Yaws Configuration
 ------------------


### PR DESCRIPTION
As requested by @tanghus I'm adding instructions to backport HTTP PATCH support into Debian stable's version of lighttpd. (See https://github.com/owncloud/contacts/issues/302 for context)
