### PR TITLE
Improved layout of PHP module deps

### DIFF
--- a/admin_manual/installation/installation_source.rst
+++ b/admin_manual/installation/installation_source.rst
@@ -25,7 +25,7 @@ Database connectors (pick at least one):
 
 * PHP module sqlite (>= 3)
 * PHP module mysql
-* PHP module pgsql
+* PHP module pgsql (requires PostgreSQL >= 9.0)
 
 And as *optional* dependencies:
 


### PR DESCRIPTION
- reordered modules alphabetically for better readability (for example when comparing with a repo package list), addresses my concern from #228 
- moved DB modules into own section

Also:
- added minimum postgreSQL version of 9, as it seems that the new syntax we use isn't supported in version 8 (see https://github.com/owncloud/core/issues/6294#issuecomment-32041954)

Please review @bantu @DeepDiver1975 @karlitschek 
