### PR TITLE
Split "optional" dependencies into "recommended" and "optional".

### DIFF
--- a/admin_manual/installation/installation_source.rst
+++ b/admin_manual/installation/installation_source.rst
@@ -27,13 +27,16 @@ Database connectors (pick at least one):
 * PHP module mysql
 * PHP module pgsql (requires PostgreSQL >= 9.0)
 
-And as *optional* dependencies:
+*Recommended* dependencies:
 
-* PHP module bz2
 * PHP module curl
-* PHP module exif (for image rotation in pictures app)
 * PHP module fileinfo
 * PHP module intl
+
+*Optional* dependencies:
+
+* PHP module bz2
+* PHP module exif (for image rotation in pictures app)
 * PHP module ldap (for ldap integration)
 * PHP module mcrypt
 * PHP module openssl


### PR DESCRIPTION
curl is used quite a few times and is obviously recommended to have
intl is probably used for translation stuff and thus good to have
fileinfo is recommended as per https://github.com/owncloud/core/issues/5516#issuecomment-27016855

not sure about:
bz2
mcrypt
openssl (this is probably required for HTTPS support, though)

@danimo @DeepDiver1975 @karlitschek @PVince81 
