### PR TITLE
Added info about JS unit testing

### DIFF
--- a/developer_manual/core/unit-testing.rst
+++ b/developer_manual/core/unit-testing.rst
@@ -115,7 +115,7 @@ Further Reading
 JavaScript unit testing for core
 --------------------------------
 
-JavasScript Unit testing for **core** and **core apps** is done using the `Karma <http://karma-runner.github.io>`_ test runner with `Jasmine <http://pivotal.github.io/jasmine/>`_.
+JavaScript Unit testing for **core** and **core apps** is done using the `Karma <http://karma-runner.github.io>`_ test runner with `Jasmine <http://pivotal.github.io/jasmine/>`_.
 
 Installing Node JS
 ~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Note: sending to **master** because JS unit tests are not available on 6.0 / stable6.
This will be for OC 7.

Still, we need to find a way for devs sending PRs to master to see this doc...
