### PR TITLE
Fix curl syntax

### DIFF
--- a/admin_manual/sharing_api/Create_a_new_Share.rst
+++ b/admin_manual/sharing_api/Create_a_new_Share.rst
@@ -190,7 +190,7 @@ Curl – Share with User
 $ curl \http://<ip>/ocs/v1.php/apps/files_sharing/api/v1/shares -k -u user:password -X POST –data "path=<file>&shareType=0&shareWith=<user>"
 
 
-output
+Output
 ------
 
 +------------------------------+-------------------------+

--- a/admin_manual/sharing_api/Delete_Share.rst
+++ b/admin_manual/sharing_api/Delete_Share.rst
@@ -46,7 +46,7 @@ Curl
 $ curl –X "DELETE" \http://<user>:<password>@<ip>/ocs/v1.php/apps/files_sharing/api/v1/files/<share_id>
 
 
-output
+Output
 ------
 
 +------------------------------+------------------------+

--- a/admin_manual/sharing_api/Get_All_Shares.rst
+++ b/admin_manual/sharing_api/Get_All_Shares.rst
@@ -29,8 +29,8 @@ The following is a list of returned status codes:
 +------------------+---------------------+
 
 
-Poster:
--------
+Poster
+------
 
 +---------------+---------------------------------------------+
 | Field         | Value                                       |
@@ -62,7 +62,7 @@ The password belongs to that user as well.
 $ curl \http://<user>:<password>@<ip>/ocs/v1.php/apps/files_sharing/api/v1/shares
 
 
-output
+Output
 ------
 
 +--------------------------------------------------------+---------------------------------------------+

--- a/admin_manual/sharing_api/Get_Information_about_a_known_share.rst
+++ b/admin_manual/sharing_api/Get_Information_about_a_known_share.rst
@@ -66,7 +66,7 @@ Curl
 $ curl \http://<user>:<passowrd>@<ip>/ocs/v1.php/apps/files_sharing/api/v1/shares/<share_id>
 
 
-output
+Output
 ------
 
 +--------------------------------------------------------+------------------------+

--- a/admin_manual/sharing_api/Get_Shares_from_a_Specific_File_or_Folder.rst
+++ b/admin_manual/sharing_api/Get_Shares_from_a_Specific_File_or_Folder.rst
@@ -47,7 +47,7 @@ The following is a list of returned status codes:
 +------------------+------------------------------------------------------+
 
 
-Poster - Default arguments
+Poster – Default arguments
 --------------------------
 
 This example shows the output of share information for “test share api/ieee.txt”
@@ -87,13 +87,13 @@ Navigate to the “Content to Send” tab and select “Body from Parameters” 
 
 Select GET.
 
-Curl – default configuration:
------------------------------
+Curl – Default configuration
+----------------------------
 
 $ curl –G –data "path=test_share_api/ieee.txt" \http://<userid>:<password>@<ip>/ocs/v1.php/apps/files_sharing/api/v1/shares
 
 
-output
+Output
 ------
 
 +--------------------------------------------------------+-------------------------------+
@@ -180,8 +180,8 @@ output
 +--------------------------------------------------------+-------------------------------+
 
 
-Poster - To add another argument, such as re-shares:
-----------------------------------------------------
+Poster – To add another argument, such as re-shares
+---------------------------------------------------
 
 This example shows the output of share information for “test share api/ieee.txt”.
 reshares is set to true which will show output if the file is re-shared by another user.
@@ -205,7 +205,7 @@ Curl – To add another argument, such as re-shares
 $ curl –G –data "path=test_share_api/ieee.tx&reshares=true" \http://<userid>:<password>@<ip>/ocs/v1.php/apps/files_sharing/api/v1/shares
 
 
-output
+Output
 ------
 
 +--------------------------------------------------------+--------------------------------------+


### PR DESCRIPTION
No spurious hyperlink on examples, and drop suggestion to run the commands
as root.
