### PR TITLE
[master] Make intl a required package

### DIFF
--- a/admin_manual/installation/installation_source.rst
+++ b/admin_manual/installation/installation_source.rst
@@ -19,6 +19,7 @@ To run ownCloud, your web server must have the following installed:
 * PHP module dom
 * PHP module GD
 * PHP module iconv
+* PHP module intl
 * PHP module JSON
 * PHP module libxml
 * PHP module mb multibyte
@@ -38,7 +39,6 @@ Database connectors (pick at least one):
   authentication, depends on this)
 * PHP module fileinfo (highly recommended, enhances file analysis performance)
 * PHP module bz2 (recommended, required for extraction of apps)
-* PHP module intl (increases language translation performance)
 * PHP module mcrypt (increases file encryption performance)
 * PHP module openssl (required for accessing HTTPS resources)
 


### PR DESCRIPTION
Make intl a required package in OC7 (submitting to master)

This is needed by https://github.com/owncloud/core/pull/7254 for the sorting collation.

Also I think I heard discussions about making that package mandatory anyway.

@DeepDiver1975 @bantu @karlitschek 

Side note: is there a reason why we still make many packages optional like fileinfo, bz2. Would it make sense to make them mandatory to avoid additional cases to support ?
