### PR TITLE
Yet another adaptation of manual install instructions, take 2

### DIFF
--- a/admin_manual/installation/installation_source.rst
+++ b/admin_manual/installation/installation_source.rst
@@ -232,7 +232,7 @@ enable SSL.
 .. note:: Self-signed certificates have their drawbacks - especially when you
           plan to make your ownCloud server publicly accessible. You might want
           to consider getting a certificate signed by an official signing
-          authority. SSLShopper for examlpe has an article on your
+          authority. SSLShopper for example has an article on your
           `options for free SSL certificates`_.
 
 Configuring ownCloud
@@ -277,8 +277,8 @@ Example config for Apache 2.4:
 
 * This config entry needs to go into the configuration file of the "site" you want
   to use.
-* On a Ubuntu system, this typically is the "default-ssl" site (to be found at
-  ``/etc/apache2/sites-available/default-ssl``).
+* On a Ubuntu system, this typically is the "default-ssl" site (to be found in
+  the :file:`/etc/apache2/sites-available/default-ssl`).
 * Edit the site file with your favorite editor (note that you'll need root
   permissions to modify that file). For Ubuntu 12.04 LTS, you could for example run
   the following command in a Terminal::
@@ -291,7 +291,7 @@ Example config for Apache 2.4:
 
   (this should be one of the last lines in the file).
 
-* A minimal site configuration on Ubuntu 12.04 might look like this:
+* A minimal site configuration file on Ubuntu 12.04 might look like this:
 
 .. code-block:: xml
 


### PR DESCRIPTION
This is the rebase of https://github.com/owncloud/documentation/pull/279, with two more commit added with:
- a few minor formatting corrections
- hints on permissions for .htaccess file
- hints on that it's not easily possible to change db system once ownCloud is set up with one.
