### PR TITLE
fixing owncloud/core#6765: avoid world writable folder

### DIFF
--- a/admin_manual/installation/installation_source.rst
+++ b/admin_manual/installation/installation_source.rst
@@ -194,6 +194,14 @@ that user.
   use ``www-data`` user
 * On ArchLinux, use ``http`` user.
 * On Fedora, use ``apache`` user.
+* When you had extracted ownCloud as user ``root``, you should adjust file and directory
+  permission to avoid world writeable files and folder::
+
+	find /path/to/your/webservers/document-root/owncloud -type d -exec chmod 750 {} \;
+	find /path/to/your/webservers/document-root/owncloud -type f -exec chmod 640 {} \;
+
+  Running this in combination with the above ``chown`` command will give a secure
+  set-up.
 
 Web Server Configuration
 ~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
when ownCloud is extracted as user root, world writable files and
folder need to be fixed

@PVince81 I think I got understood PR now...it's just that I have patched against stable6...can this also be merged into master?
