### PR TITLE
Update link to OC 6 documents

### DIFF
--- a/developer_manual/devenv/index.rst
+++ b/developer_manual/devenv/index.rst
@@ -9,7 +9,7 @@ Please follow the steps on this page to set up your development environment.
 Set up web server and database
 ------------------------------
 
-First `set up your webserver and database <http://doc.owncloud.org/server/5.0/admin_manual/installation.html>`_ (**Section**: Manual Installation - Prerequisites).
+First `set up your webserver and database <http://doc.owncloud.org/server/6.0/admin_manual/installation/installation_source.html>`_ (**Section**: Manual Installation - Prerequisites).
 
 Get the source
 --------------


### PR DESCRIPTION
We want the OC 6 admin manual to be linked with the OC 6 development docs

```
make html
```

passed OK
