### PR TITLE
Use 6.x version numbers in examples.

### DIFF
--- a/admin_manual/maintenance/update.rst
+++ b/admin_manual/maintenance/update.rst
@@ -6,7 +6,7 @@ Updating ownCloud
 
 Update
 ------
-Updating means updating ownCloud to the latest *point release*, e.g. ownCloud 5.0.13 → 5.0.14a. This procedure uses the
+Updating means updating ownCloud to the latest *point release*, e.g. ownCloud 6.0.0a → 6.0.2. This procedure uses the
 ownCloud updater plugin called "Updater": it's an internal application already present in your ownCloud installation.
 
 To update ownCloud, follow those steps:


### PR DESCRIPTION
It is a bit confusing to have version numbers of the previous major release in the example. To me it always feels like no one had a look if the documentation was up-to-date for the current release.
