### PR TITLE
Many claim are erroneous like the existence of a folder default in themes

### DIFF
--- a/developer_manual/core/theming.rst
+++ b/developer_manual/core/theming.rst
@@ -18,25 +18,77 @@ With this facts you can easyly determine, where the following object-related att
 * links
 * graphics
 
-In owncloud standard theme everything is held very simple. This allows you quick adpating. In an unchanged ownCloud version css files and the standard pictures reside in /owncloud/themes/default folder.
-The next thing you should do, before starting any changes is:
-Make a backup of your current theme(s) e.g.:
-
-* Goto …/owncloud/themes
-* cp -r default default.old
-
 Creating and activating a new theme
 ===================================
 
 There are two basic ways of creating new themings:
 
 * Doing all new from scratch
+	In owncloud standard theme everything is held very simple. This allows you quick adapting. In an unchanged ownCloud version css files and the standard pictures reside in:
+	- /owncloud/core/css
+	- /owncloud/core/img
+	- /owncloud/settings/templates
+	
+	Create a folder in /owncloud/themes and necessary subfolder
+		* mkdir -p mynewtheme ./mynewtheme/core/css ./mynewtheme/settings/templates
+		
+
 * Starting from an existing theme and doing everything step by step and more experimentally
+	In owncloud standard theme everything is held very simple. This allows you quick adapting. In an unchanged ownCloud version css files and the standard pictures reside in:
+	- /owncloud/core/css
+	- /owncloud/core/img
+	- /owncloud/settings/templates
 
-Depending on how you created your new theme it will be necessary to
+The next thing you should do, before starting any changes is:
+Create a new folder for your new theme(s) and copy the basic files and modify them to create your new theme e.g.:
 
-* put a new theme into the /themes -folder. The theme can be activated by putting "theme" => ‘themename’, into the config.php file.
-* make all changes in the /themes/default -file
+* cd …/owncloud/themes
+* mkdir mynewtheme 
+* cp -Rf ../core/css ./mynewtheme
+* cp -Rf ../core/route.php ./mynewtheme # This is a required file
+* cp -Rf ../core/css ./mynewtheme
+* cp -Rf ../core/img ./mynewtheme
+* cp -Rf ../settings/templates ./mynewtheme
+
+Files of interest:
+- /owncloud/core/css/style.css  # Contain the css that define the color of the login page and header *Search header keyword in file* 
+	.. code-block::
+
+	  /* HEADERS */
+	 ...
+	  background: #1d2d42; /* Old browsers */
+	  background: -moz-linear-gradient(top, #33537a 0%, #1d2d42  100%); /* FF3.6+ */
+	  background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,#F1B3A4), color-stop(100%,#1d2d42)); /* Chrome,Safari4+ */
+	  background: -webkit-linear-gradient(top, #33537a 0%,#1d2d42 100%); /* Chrome10+,Safari5.1+ */
+	  background: -o-linear-gradient(top, #33537a 0%,#1d2d42 100%); /* Opera11.10+ */
+	  background: -ms-linear-gradient(top, #33537a 0%,#1d2d42 100%); /* IE10+ */
+	  background: linear-gradient(top, #33537a 0%,#1d2d42 100%); /* W3C */
+
+- /owncloud/settings/templates/personal.php # Contain the copyright displayed in personal page
+- /owncloud/settings/templates/admin.php # Contain the copyright displayed in admin page	
+- /owncloud/lib/private/defaults.php # Contain a configuration section to rename the application to your custom name.  !! This file cannot be copied in your custom theme folder. 
+	.. code-block::
+	
+		function __construct() {
+				$this->l = OC_L10N::get('core');
+
+				$this->defaultEntity = "YopCloud"; /* e.g. company name, used for footers and copyright notices */
+				$this->defaultName = "YopCloud"; /* short name, used when referring to the software */
+				$this->defaultTitle = "YopCloud"; /* can be a longer name, for titles */
+				$this->defaultBaseUrl = "http://drive.yopcloud.com";
+				$this->defaultSyncClientUrl = " http://owncloud.org/sync-clients/";
+				$this->defaultDocBaseUrl = "http://doc.owncloud.org";
+				$this->defaultSlogan = $this->l->t("Your Own Private Cloud");
+				$this->defaultLogoClaim = "";
+
+				if (class_exists("OC_Theme")) {
+						$this->theme = new OC_Theme();
+				}
+		}
+
+
+The theme can be activated by putting "theme" => ‘themename’, into the config.php file.
+
 
 Structure
 =========
@@ -57,31 +109,32 @@ Figure out the path of the old logo
 
 Replace the old pictue, which postition you found out as described under 1.3. by adding an extension in case you want to re-use it later.
 
-Creating an own logo
+Creating your own logo
 --------------------
 
 If you want to do a quick exchange like (1) it's important to know the size of the picture before you start creating an own logo:
 
-* Go to the place in the filesystem, that has been shown by the webdeveloper tool/s
+* Go to the place in the filesystem, that has been shown by the web developer tools
 * You can look up sizing in most cases via the file properties inside your file-manager
 * Create an own picture/logo with the same size then
 
 The (main) pictures, that can be found inside ownCloud standard theming are the following:
 
-* The logo at the login-page above the credentials-box: 	        …/owncloud/themes/default/core/img/logo.svg
-* The logo, that's always in the left upper corner after login:   …/owncloud/themes/default/core/img/logo-wide.svg
+* The logo at the login-page above the credentials-box: 	        …/owncloud/core/img/logo.svg 
+* The logo, that's always in the left upper corner after login:   …/owncloud/core/img/logo-wide.svg  
 
 Inserting your new logo
 -----------------------
-Inserting a new logo into an existing theme is as simple as replacing the old logo with the new (genreated) one.
-You can use: scalable vector graphics (.svg) or common graphics formats for the internet such as portable network graphics (.png) or .jepg
+Inserting a new logo into an existing theme is as simple as replacing the old logo with the new (generated) one.
+You can use: scalable vector graphics (.svg) or common graphics formats for the internet such as portable network graphics (.png) or .jpeg
 Just insert the new created picture by using the unchanged name of the old picture.
 
 changing the default colours
 ----------------------------
 
-With a web-developer tool like Mozilla-Inspector, you also get easyly displayed the color of the background you klicked on.
-On the top of the login page you can see a case- destinguished setting for different browsers:
+With a web-developer tool like Mozilla-Inspector, you also get easily display the color of the background you clicked on.
+On the top of the login page you can see a case- distinguished setting for different browsers:
+
 
 .. code-block::
 


### PR DESCRIPTION
1- Many claim are erroneous like the existence of a folder default in themes

2- All default files are in /core and /settings and the current version doesn't use the theming system for its default interface.

There were no information about what file should be updated or are of interest.

Please someone validate that claim, I'm not sure if I'm right that this file cannot be located in theme folder to be effective!

If I'm right, please open a bug in Core to add a feature to modify these value from admin page.
- /owncloud/lib/private/defaults.php # Contain a configuration section to rename the application to your custom name.  !! This file cannot be copied in your custom theme folder.
