### PR TITLE
fixed typo at nginx sample configuration

### DIFF
--- a/admin_manual/installation/installation_source.rst
+++ b/admin_manual/installation/installation_source.rst
@@ -474,7 +474,8 @@ Nginx Configuration
 
     }
 
-To disable SSL support:
+.. note:: You can use Owncloud without SSL/TLS support, but we strongly encourage you not to do that:
+
 -  Remove the server block containing the redirect
 -  Change **listen 443 ssl** to **listen 80;**
 -  Remove **ssl_certificate** and **ssl_certificate_key**.


### PR DESCRIPTION
There is a little mistake after the nginx sample configuration. The block tells how to disable SSL within the sample config, but it starts with "To enable SSL:" - It should be "To disable SSL:".
