### PR TITLE
Fix figure captions to prevent going them to the next page without captions

### DIFF
--- a/user_manual/documents.rst
+++ b/user_manual/documents.rst
@@ -11,7 +11,7 @@ sent be email. The editing works on top of normal ODF files that are stored in o
 The main interface
 ------------------
 
-.. figure:: images/oc_documents.png
+.. image:: images/oc_documents.png
 
 Create/Upload a Document
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -27,7 +27,7 @@ If ownCloud contains at least one ODT file, you can immediately start editing by
 the file within the documents app. Clicking on documents in files app will only display it. Below, you
 can see editing a newly created document file:
 
-.. figure:: images/oc_documents_edit.png
+.. image:: images/oc_documents_edit.png
 
 Here is the explanation of each field in the image shown above:
 

--- a/user_manual/files/filesweb.rst
+++ b/user_manual/files/filesweb.rst
@@ -135,5 +135,4 @@ To share a file or folder:
 
 		.. figure:: ../images/oc_share_expiration_calendar.png
 
-		Expiration Date Calendar
-
+		   Expiration Date Calendar

--- a/user_manual/pim/contacts.rst
+++ b/user_manual/pim/contacts.rst
@@ -21,13 +21,13 @@ So first we'll check out how to import all the VCF files as they are a lot
 more faster way of creating contacts.
 Just below the contact list, click on the gear button:
 
-.. image:: ../images/contact_bottombar.png
+.. figure:: ../images/contact_bottombar.png
 
    Contact settings icon
 
 Once you've clicked it, an up arrow button which lets you upload files will be shown:
 
-.. image:: ../images/contact_uploadbutton.png
+.. figure:: ../images/contact_uploadbutton.png
 
    Contact file upload icon
 
@@ -42,7 +42,7 @@ After you are done just click on the ``Open`` button.
 After the upload it should look something like this in which all the names and
 contacts will be sorted alphabetically
 
-.. image:: ../images/contact_vcfpick.jpg
+.. figure:: ../images/contact_vcfpick.jpg
 
    Picking VCF files
 
@@ -60,9 +60,9 @@ the name, the address, the e-mail, the telephone nr, etc.
 Just click on a field and start typing the information.
 You can use the "Add Field" button to add another types of information for this contact.
 
-.. image:: ../images/contact_emptycontact.png
+.. figure:: ../images/contact_emptycontact.png
 
-Empty contact view
+   Empty contact view
 
 When you want to remove an information of your contact, just click on little delete icon
 at the right of the field you want to remove.
@@ -72,7 +72,7 @@ Adding picture to the contact
 
 There are two methods in which you can give a picture id to the specific contact
 
-.. image:: ../images/contact_picture.jpg
+.. figure:: ../images/contact_picture.jpg
 
    Contact picture options
 
@@ -82,7 +82,7 @@ There are two methods in which you can give a picture id to the specific contact
 After you have selected the picture for the contact you get
 an option to crop the picture to suit your requirements
 
-.. image:: ../images/contact_crop.jpg
+.. figure:: ../images/contact_crop.jpg
 
    Cropping contact picture
 
@@ -99,7 +99,7 @@ When you click on settings button on bottom bar,
 you will have access to the application's settings.
 Then, you will be shown all available addressbooks to access the options.
 
-.. image:: ../images/contact_del_ab.png
+.. figure:: ../images/contact_del_ab.png
 
    Addressbook options
 
@@ -123,7 +123,7 @@ Syncing with Android
 4) After the app has checked your login details you may just select- Sync server to phone option
 5) That's it there is nothing else to do for Android :)
 
-.. image:: ../images/contact_syncopt.jpg
+.. figure:: ../images/contact_syncopt.jpg
 
 Syncing your iOS device
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/user_manual/pim/sync_thunderbird.rst
+++ b/user_manual/pim/sync_thunderbird.rst
@@ -16,7 +16,7 @@ With an installed Thunderbird mailtool, and installed SoGo Connector:
 
    -  "File > New > **Remote Addressbook**" (SoGo Connector added this)
    -  "**Name:**" is the name you want to give your Addressbook in the Thunderbird addressbook bar area
-   -  "**URL:**" is found in your OwnCloud Contacts area, that little Gear symbol
+   -  "**URL:**" is found in your ownCloud Contacts area, that little Gear symbol
 
 .. image:: ../images/contact_thunderbird-Symbol_Gear.jpg
 


### PR DESCRIPTION
Images can be used without captions and all the text is moved below the image if it does not fit into the page. However, figures are smarter with captions and only **they** are moved if they do not fit the current page whereas the text stays where it was.

We should use `image` if we do not have a caption and specify the image as `Like the image below:`. Otherwise, in the generated PDF we see those images in the next pages.

See the report [here](https://bitbucket.org/birkenfeld/sphinx/issue/1482/forcing-images-to-be-seen-in-the-same-page).
