### PR TITLE
Remove try_files that was causing issues

### DIFF
--- a/admin_manual/installation/installation_source.rst
+++ b/admin_manual/installation/installation_source.rst
@@ -448,8 +448,6 @@ Nginx Configuration
 
             location ~ \.php(?:$|/) {
                     fastcgi_split_path_info ^(.+\.php)(/.+)$;
-                    try_files $fastcgi_script_name =404;
-
                     include fastcgi_params;
                     fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
                     fastcgi_param PATH_INFO $fastcgi_path_info;


### PR DESCRIPTION
This 'try_files' was probably originally put in as a security measure against maliciously uploaded static objects that would be then executed as php. See here https://nealpoole.com/blog/2011/04/setting-up-php-fastcgi-and-nginx-dont-trust-the-tutorials-check-your-configuration/

This is not needed because 'fastcgi_split_path_info' line already guarantees only the intended php file is passed to PHP as the SCRIPT_FILENAME.
