### PR TITLE
Recommend GMP extension for SFTP

### DIFF
--- a/admin_manual/installation/installation_source.rst
+++ b/admin_manual/installation/installation_source.rst
@@ -57,6 +57,7 @@ package):
 Recommended for specific apps (*optional*):
 
 * PHP module exif (for image rotation in pictures app)
+* PHP module gmp (for SFTP storage)
 
 For enhanced performance (*optional* / select only one of the following):
 


### PR DESCRIPTION
SFTP is based on SSH which performs Diffie-Hellman Key Agreement. If GMP is available, phpseclib will make use of it (via its BigInteger class).
