### PR TITLE
add expire date to share api documentation

### DIFF
--- a/developer_manual/core/ocs-share-api.rst
+++ b/developer_manual/core/ocs-share-api.rst
@@ -121,7 +121,7 @@ Update a given share. Only one value can be updated per request.
 * PUT Arguments: expireDate - (string) set a expire date for public link
   shares. This argument expects a well formated date string, e.g. 'YYYY-MM-DD'
 
-.. note:: Only one of "password" or "publicUpload" can be specified at once.
+.. note:: Only one of the update parameters can be specified at once.
 
 Statuscodes:
 


### PR DESCRIPTION
add documentation for expire date update, will be available once this PR is merged and backported to OC7: https://github.com/owncloud/core/pull/9798
