### PR TITLE
Fix ".well-know" rewrites

### DIFF
--- a/admin_manual/installation/installation_source.rst
+++ b/admin_manual/installation/installation_source.rst
@@ -425,7 +425,7 @@ Nginx Configuration
                 access_log off;
             }
 
-            location ~ ^/(?:\.|data|config|db_structure\.xml|README) {
+            location ~ ^/(?:\.htaccess|data|config|db_structure\.xml|README) {
                     deny all;
             }
 


### PR DESCRIPTION
Fixing a bug I introduced. Normally all dot file "." should be hidden but ownCloud uses a few for some purpose.

Fixes https://github.com/owncloud/documentation/issues/435
