### PR TITLE
Route calls to index.php via try_files with nginx

### DIFF
--- a/admin_manual/installation/configuration_nginx.rst
+++ b/admin_manual/installation/configuration_nginx.rst
@@ -62,7 +62,7 @@ Nginx Configuration
 
      rewrite ^(/core/doc/[^\/]+/)$ $1/index.html;
 
-     try_files $uri $uri/ index.php;
+     try_files $uri $uri/ /index.php;
      }
 
      location ~ \.php(?:$|/) {


### PR DESCRIPTION
This makes short(er) sharing links even shorter, and would be neat for https://github.com/owncloud/core/tree/shorter_sharing_links (whenever I may finish that …)

E.g.:
https://yourcloud.com/s/3pyaiaav7bt2i
instead of
https://yourcloud.com/index.php/s/3pyaiaav7bt2i
(instead of
https://yourcloud.com/public.php?service=files&t=e91d871628e40fa23ac101a8e26805be
we have right now)

@PVince81 
@josh4trunks 
