### PR TITLE
Remove not longer existing config switch

### DIFF
--- a/developer_manual/core/configfile.rst
+++ b/developer_manual/core/configfile.rst
@@ -35,12 +35,6 @@ App config
   /* Force use of HTTPS connection (true = use HTTPS) */
   "forcessl" => false,
 
-  /* Enhanced auth forces users to enter their password again when performing potential sensitive actions like creating or deleting users */
-  "enhancedauth" => true,
-
-  /* Time in seconds how long an user is authenticated without entering his password again before performing sensitive actions like creating or deleting users etc...*/
-  "enhancedauthtime" => 15 * 60,
-
   /* Theme to use for ownCloud */
   "theme" => "",
 


### PR DESCRIPTION
Was removed with ownCloud 3.x or so - killing it here too.
