### PR TITLE
Added warning to use php 5.4 or greater

### DIFF
--- a/admin_manual/configuration/auth_ldap.rst
+++ b/admin_manual/configuration/auth_ldap.rst
@@ -5,8 +5,8 @@ ownCloud ships with an LDAP application so that your existing LDAP users may
 have access to your ownCloud server without creating separate ownCloud user 
 accounts.
 
-.. Note:: For performance reasons you must have PHP 5.4 or greater to use the 
-   LDAP application with more than 500 users.
+.. Note:: For performance reasons, we recommend using PHP 5.4 or greater to use 
+   the LDAP application with more than 500 users.
 
 The LDAP application supports:
 


### PR DESCRIPTION
@MTRichards @blizzz -- If you want more explanation, for example to say 5.3 is OK with caveats, chime in. Me, I'm fine with 5.4 and fie on 5.3.
