### PR TITLE
better handling of custom certificates

### DIFF
--- a/user_manual/files/files.rst
+++ b/user_manual/files/files.rst
@@ -106,9 +106,10 @@ Known Issues
 
 **Problem:** Certificate warnings
 
-**Solution:** If you use a self-signed certificate, you will get a warning. If you are willing to take the risk of a man in the middle attack, run this command instead::
-
-    echo "y" | mount ~/owncloud > /dev/null 2>&1
+**Solution:** If you use a self-signed certificate, you will get a warning. To change this, you need to adress the "pem"-file of your certificate. 
+At first copy ``mycertificate.pem`` to  - for example - ``/etc/davfs2/certs/``. After that edit :file:`/etc/davfs2/davfs2.conf` and uncomment the line ``servercert`` (or add it). 
+Now add the path of your certificate. In this this example::
+    servercert   /etc/davfs2/certs/mycertificate.pem
 
 Accessing Files Using MAC OSX
 -----------------------------


### PR DESCRIPTION
I followed your steps to setup webdav via command-line. I also use a custom certificate and thought, that it is a bad idea to not check the fingerprint of the certificate. I solved it, by addressing the "pem"-file in the configuration. I think this is a far better solution.

Regards
