### PR TITLE
Add guideline about annotation using one-line

### DIFF
--- a/developer_manual/general/codingguidelines.rst
+++ b/developer_manual/general/codingguidelines.rst
@@ -76,6 +76,24 @@ All API methods need to be marked with `PHPDoc <http://en.wikipedia.org/wiki/PHP
     // ...
   }
 
+All member variables of a class needs to be type annotated within a single line DocComment using 
+`PHPDoc <http://en.wikipedia.org/wiki/PHPDoc>`_ markup. An example would be:
+
+.. code-block:: php
+
+	<?php
+	
+	class Foo {
+		/** @var \OC_Defaults */
+		private $defaults;
+	
+		/**
+		 * @param \OC_Defaults $defaults
+		 */
+		public function __construct(\OC_Defaults $defaults) {
+			$this->defaults = $defaults;
+		}
+	}
 Objects, Functions, Arrays & Variables
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Use Pascal case for Objects, Camel case for functions and variables. If you set

--- a/developer_manual/general/codingguidelines.rst
+++ b/developer_manual/general/codingguidelines.rst
@@ -86,12 +86,16 @@ All member variables of a class needs to be type annotated within a single line 
 	class Foo {
 		/** @var \OC_Defaults */
 		private $defaults;
+		/** @var \OCP\IRequest */
+		private $request;
 	
 		/**
 		 * @param \OC_Defaults $defaults
+		 * @param \OCP\IRequest $request
 		 */
-		public function __construct(\OC_Defaults $defaults) {
+		public function __construct(\OC_Defaults $defaults, \OCP\IRequest $request) {
 			$this->defaults = $defaults;
+			$this->request = $request;
 		}
 	}
 Objects, Functions, Arrays & Variables


### PR DESCRIPTION
From https://github.com/owncloud/core/pull/12279#discussion_r20546875

Opinions:
- @blizzz: 1 use-statement/relative
- @butonic: 1 use-statement - switch to @type as PSR5
- @Raydiation: 1 use-statement - switch to @type as PSR5
- @icewind1991: 3 full qualified
- @LukasReschke: ~~1 full qualified~~ 1 use-statement - switch to @type as PSR5
- @MorrisJobke: ~~1 full qualified~~ 1 use-statement - switch to @type as PSR5
- @nickvergessen: 1 line