### PR TITLE
Correct a typo at admin/config section smb

### DIFF
--- a/admin_manual/configuration/external_storage_configuration_gui.rst
+++ b/admin_manual/configuration/external_storage_configuration_gui.rst
@@ -265,7 +265,7 @@ You need the following information:
 
 *   Folder name -- Whatever name you want for your local mountpoint.
 *   Host -- The URL of the Samba server.
-*   Username* -- The username or domain/username used to login to the Samba server.
+*   Username -- The username or domain/username used to login to the Samba server.
 *   Password -- The password to login to the Samba server.
 *   Share -- The share on the Samba server to mount.
 *   Root -- The folder inside the Samba share to mount (optional, defaults to 


### PR DESCRIPTION
Originaly I wanted to add a info based on a experience I made, but instead of creating a PR, I commited the change immediate where I have to excuse for. This PR is to show what has been changed and a small correction of a typo in the gui version which should be merged to to have everything clean (just a remove of an unnecessary *). Just to say, that I found out the cause of my mishap...

What´s about:

When you use files_externals with smb, you have to fill in the user you want to grant against. In some cases, you will not get a green light even if everything has been entered correctly. What I found out is, that you may have to add the domain name to the user, especially if the server has not joined a domain. The change is a addition and instead typing "user" I needed to type "domain/user". Having this entered properly, the light turned immediate to green and everything worked.

Because this info was nowhere present, I changed following two files to reflect this:

documentation/admin_manual/configuration/
external_storage_configuration.rst
external_storage_configuration_gui.rst

In the non gui version, I additionally added a second example to reflect this properly.
