### PR TITLE
Pass the HTTP status code directly in the constructor

### DIFF
--- a/developer_manual/app/controllers.rst
+++ b/developer_manual/app/controllers.rst
@@ -469,7 +469,7 @@ Each response subclass has access to the **setStatus** method which lets you set
                 // try to get author with $id
 
             } catch (NotFoundException $ex) {
-                return new JSONResponse()->setStatus(Http::STATUS_NOT_FOUND);
+                return new JSONResponse(array(), Http::STATUS_NOT_FOUND);
             }
         }
 


### PR DESCRIPTION
My IDE is telling me this way of doing things doesn't not work

```
return new JSONResponse()->setStatus(Http::STATUS_NOT_FOUND);
```
