### PR TITLE
Note for external storage types that use temp space

### DIFF
--- a/admin_manual/configuration/external_storage_configuration.rst
+++ b/admin_manual/configuration/external_storage_configuration.rst
@@ -98,11 +98,11 @@ Therefore ownCloud needs temporary space to buffer data for transfers. This can 
 when there are many concurrent users transferring data with a higher volume over a small 
 bandwidth wire. ownCloud may need in these cases an amount of temporary space which could 
 exeed the server capabilities. Example: 100 concurrent users uploading each a file having 
-300MB with a total transfer trime of 6000s (1h 40min). The temporary space needed 
+300MB with a total transfer time of 6000s (1h 40min). The temporary space needed 
 by ownCloud for this period of time is 30GB. Even though it is not mandatory,
 the location of the temp directory used by ownCloud can be configured manually.
-To do so, you need to maintain the 'tempdirectory' parameter described in
-config.sample.php
+To do so, you need to maintain the ``tempdirectory`` parameter described in
+``config.sample.php``
 
 As of writing, following external storage list uses temp files for up/download:
 

--- a/admin_manual/configuration/external_storage_configuration_gui.rst
+++ b/admin_manual/configuration/external_storage_configuration_gui.rst
@@ -59,11 +59,11 @@ Therefore ownCloud needs temporary space to buffer data for transfers. This can 
 when there are many concurrent users transferring data with a higher volume over a small 
 bandwidth wire. ownCloud may need in these cases an amount of temporary space which could 
 exeed the server capabilities. Example: 100 concurrent users uploading each a file having 
-300MB with a total transfer trime of 6000s (1h 40min). The temporary space needed 
+300MB with a total transfer time of 6000s (1h 40min). The temporary space needed 
 by ownCloud for this period of time is 30GB. Even though it is not mandatory,
 the location of the temp directory used by ownCloud can be configured manually.
-To do so, you need to maintain the 'tempdirectory' parameter described in
-config.sample.php
+To do so, you need to maintain the ``tempdirectory`` parameter described in
+``config.sample.php``
 
 As of writing, following external storage list uses temp files for up/download:
 


### PR DESCRIPTION
**Do not merge before https://github.com/owncloud/core/pull/13031**
**If the above PR gets merged, this one should be merged to finalize the documentation**

This PR documents that some external storage types may need a higher temporary disk space due to lack of steaming capabilities and references to a parameter to configure the temp dir location which is defined in core 13031

The note is written in configuration/external_storage_configuration gui and non gui version.
