### PR TITLE
add double backticks to $user in config/smb to have the same look as in ...

### DIFF
--- a/admin_manual/configuration/external_storage_configuration.rst
+++ b/admin_manual/configuration/external_storage_configuration.rst
@@ -224,7 +224,7 @@ takes the following options:
 -  **password**: the password to login on the samba server
 -  **share**: the share on the samba server to mount
 -  **root**: the folder inside the samba share to mount (optional, defaults
-   to ‘/’). To assign the ownCloud logon username automatically to the subfolder, use $user instead of a particular subfolder name.
+   to ‘/’). To assign the ownCloud logon username automatically to the subfolder, use ``$user`` instead of a particular subfolder name.
 
 .. note:: The SMB backend requires **smbclient** to be installed on the server.
 

--- a/admin_manual/configuration/external_storage_configuration_gui.rst
+++ b/admin_manual/configuration/external_storage_configuration_gui.rst
@@ -299,7 +299,7 @@ You need the following information:
 *   Password -- The password to login to the Samba server.
 *   Share -- The share on the Samba server to mount.
 *   Root -- The folder inside the Samba share to mount (optional, defaults to 
-    ``/``). To assign the ownCloud logon username automatically to the subfolder, use $user instead of a particular subfolder name.
+    ``/``). To assign the ownCloud logon username automatically to the subfolder, use ``$user`` instead of a particular subfolder name.
 
 And finally, the ownCloud users and groups who get access to the share.    
 


### PR DESCRIPTION
...stable7

this references to #711 where for stable7 in section smb at the term $user double backticks have been used but not for master.
This PR fixes this.
@carlaschroder please review and merge