### PR TITLE
Add changelog for owncloud 8

### DIFF
--- a/developer_manual/app/changelog.rst
+++ b/developer_manual/app/changelog.rst
@@ -36,3 +36,4 @@ Features
 * The :doc:`container <container>` can now automatically resolve and build classes based on type hints and variable naming conventions
 * :doc:`Routes <routes>` can now be returned as an array in **appinfo/routes.php** if the **<namespace>** tag is set in **appinfo/info.xml**. The :doc:`container <container>` must either be omitted or available under **appinfo/application.php** and named **OCA\\YourApp\\YourNamespace\\AppInfo\\Application**
 * **vendor_script** and **vendor_style** :doc:`template functions <templates>` have been added to load styles and scripts from your **vendor** folder
+* The documentation now features an :doc:`app tutorial <tutorial>`

--- a/developer_manual/app/changelog.rst
+++ b/developer_manual/app/changelog.rst
@@ -1,0 +1,38 @@
+=========
+Changelog
+=========
+
+.. sectionauthor:: Bernhard Posselt <dev@bernhard-posselt.com>
+
+The following changes went into ownCloud 8:
+
+
+Breaking changes
+================
+
+* Setting session variables inside a controller requires the **@UseSession** annotation, otherwise the session will be closed
+
+Deprecations
+============
+
+.. note:: Deprecations on interfaces also affect the implementing classes!
+
+* `OCP\\AppFramework\\IApi <https://github.com/owncloud/core/blob/d59c4e832fea87d03d199a3211186a47fd252c32/lib/public/appframework/iapi.php>`_: full class. Removal planned in **8.3**
+* `OCP\\AppFramework\\IAppContainer <https://github.com/owncloud/core/blob/d59c4e832fea87d03d199a3211186a47fd252c32/lib/public/appframework/iappcontainer.php>`_: methods **getCoreApi** and **log**. Removal planned in **8.3**
+* `OCP\\AppFramework\\Controller <https://github.com/owncloud/core/blob/d59c4e832fea87d03d199a3211186a47fd252c32/lib/public/appframework/controller.php>`_: methods **params**, **getParams**, **method**, **getUploadedFile**, **env**, **cookie**, **render**. Removal planned in **8.3**
+
+Features
+========
+
+* The :doc:`info.xml <info>` file in **appinfo/info.xml** now supports library, command, php and database dependencies that are checked before app installation
+* Various other tags for :doc:`info.xml <info>` have been added that are related to the app store
+* :doc:`Routes <routes>` received the **defaults** parameter to set route variable defaults when not given
+* :doc:`Routes <routes>` received the **postfix** parameter to allow multiple urls pointing at the same resource
+* :doc:`Menu buttons <css>` can now be added easily for navigation entries
+* **OCP\\AppFramework\\DataResponse** can now be used to wrap data and set Http error codes when using responders
+* :doc:`Navigation entry undo and edit styles <css>` have been added
+* **OCP\\AppFramework\\HttpResponse** now supports setting cookies
+* A :doc:`container <container>` is now optional
+* The :doc:`container <container>` can now automatically resolve and build classes based on type hints and variable naming conventions
+* :doc:`Routes <routes>` can now be returned as an array in **appinfo/routes.php** if the **<namespace>** tag is set in **appinfo/info.xml**. The :doc:`container <container>` must either be omitted or available under **appinfo/application.php** and named **OCA\\YourApp\\YourNamespace\\AppInfo\\Application**
+* **vendor_script** and **vendor_style** :doc:`template functions <templates>` have been added to load styles and scripts from your **vendor** folder

--- a/developer_manual/app/changelog.rst
+++ b/developer_manual/app/changelog.rst
@@ -21,6 +21,14 @@ Deprecations
 * `OCP\\AppFramework\\IAppContainer <https://github.com/owncloud/core/blob/d59c4e832fea87d03d199a3211186a47fd252c32/lib/public/appframework/iappcontainer.php>`_: methods **getCoreApi** and **log**. Removal planned in **8.3**
 * `OCP\\AppFramework\\Controller <https://github.com/owncloud/core/blob/d59c4e832fea87d03d199a3211186a47fd252c32/lib/public/appframework/controller.php>`_: methods **params**, **getParams**, **method**, **getUploadedFile**, **env**, **cookie**, **render**. Removal planned in **8.3**
 
+.. note:: Deprecations of constants and methods with namespaces!
+
+* The following methods have been moved into the **OCP\\Template::<method>** class instead of being namespaced directly:
+**OCP\\image_path**, **OCP\\mimetype_icon**, **OCP\\preview_icon**, **OCP\\publicPreview_icon**, **OCP\\human_file_size**, **OCP\\relative_modified_date**, **OCP\\html_select_options**. Removal planned in **9.0**
+* **OCP\\simple_file_size** has been deprecated in favour of **OCP\\Template::human_file_size**. Removal planned in **9.0**
+* The **OCP\\PERMISSION_<permission>** and **OCP\\FILENAME_INVALID_CHARS** have been moved to **OCP\\Constants::<old name>**. Removal planned in **9.0**
+* The **OC_GROUP_BACKEND_<method>** and **OC_USER_BACKEND_<method>** have been moved to **OC_Group_Backend::<method>** and **OC_User_Backend::<method>** respectively. Removal planned in **9.0**
+
 Features
 ========
 

--- a/developer_manual/app/index.rst
+++ b/developer_manual/app/index.rst
@@ -7,6 +7,7 @@
    :maxdepth: 2
    :hidden:
 
+   changelog
    tutorial
    startapp
    init
@@ -57,6 +58,10 @@ After this you can start with the tutorial
 
 App development
 ===============
+Take a look at the changes in this version:
+
+* :doc:`changelog`
+
 Create a new app:
 
 * :doc:`startapp`

--- a/developer_manual/app/info.rst
+++ b/developer_manual/app/info.rst
@@ -17,6 +17,7 @@ The :file:`appinfo/info.xml` contains metadata about the app:
       <licence>AGPL</licence>
       <author>Your Name</author>
       <requiremin>5</requiremin>
+      <namespace>YourAppsNamespace</namespace>
 
       <types>
           <type>filesystem</type>
@@ -28,7 +29,15 @@ The :file:`appinfo/info.xml` contains metadata about the app:
           <admin>http://doc.owncloud.org</admin>
       </documentation>
 
+      <category>other</category>
+
       <website>http://www.owncloud.org</website>
+
+      <bugs>http://github.com/owncloud/theapp/issues</bugs>
+
+      <repository type="git">http://github.com/owncloud/theapp.git</repository>
+
+      <ocsid>1234</ocsid>
 
       <!-- deprecated, just for reference -->
       <public>
@@ -89,7 +98,11 @@ author
 
 requiremin
 ----------
-**Required**: The minimal version of ownCloud.
+Required if not added in the **<dependencies>** tag. The minimal version of ownCloud.
+
+namespace
+---------
+Required if routes.php returns an array. If your app is namespaced like **\\OCA\\MyApp\\Controller\\PageController** the required namespace value is **MyApp**. If not given it tries to default to the first letter upper cased app id, e.g. **myapp** would be tried under **Myapp**
 
 types
 -----
@@ -110,6 +123,29 @@ link to 'admin' and 'user' documentation
 website
 -------
 link to project web page
+
+repository
+----------
+Link to the version control repo
+
+bugs
+----
+Link to the bug tracker
+
+category
+--------
+Category on the app store. Can be one of the following:
+
+* other
+* multimedia
+* pim
+* productivity
+* games
+* tools
+
+ocsid
+-----
+The app's id on the app store, e.g.: https://apps.owncloud.com/content/show.php/QOwnNotes?content=168497 would have the ocsid **168497**. If given helps users to install and update the same app from the app store
 
 Dependencies
 ============

--- a/developer_manual/app/users.rst
+++ b/developer_manual/app/users.rst
@@ -246,7 +246,7 @@ Then session variables can be accessed like this:
     }
 
 Managing cookies
-===================
+================
 To set, get or modify cookies the `request` variable and the `response` class can be used from within controllers:
 
 .. code-block:: php


### PR DESCRIPTION
I've added a changelog to the developer docs (+ other small fixes) because its quite hard to keep up with all the changes and I think its not a good idea to only rely on the dev mailing list to announce deprecations and changes

@DeepDiver1975 @MorrisJobke @jbtbnl @jancborchardt @georgehrke @LEDfan @PVince81 @nickvergessen @LukasReschke 

@karlitschek when merged this can be included in the release notes