### PR TITLE
Documentation for core#13031 (Configurabe owncloud temporary directory)

### DIFF
--- a/admin_manual/configuration_files/external_storage_configuration.rst
+++ b/admin_manual/configuration_files/external_storage_configuration.rst
@@ -119,6 +119,35 @@ following order, with later mount types always overriding a previous mount type:
 -  user (not all) : per-user mount configurations
 -  :file:`data/$user/mount.json` : personal mount configurations
 
+Note regarding temporary disk space needs
+-----------------------------------------
+
+Not all external storage types are currently enabled for or do support streaming.
+Therefore ownCloud needs temporary space to buffer data for transfers. This can occur 
+when there are many concurrent users transferring data with a higher volume over a small 
+bandwidth wire. ownCloud may need in these cases an amount of temporary space which could 
+exeed the server capabilities. Example: 100 concurrent users uploading each a file having 
+300MB with a total transfer time of 6000s (1h 40min). The temporary space needed 
+by ownCloud for this period of time is 30GB. Even though it is not mandatory,
+the location of the temp directory used by ownCloud can be configured manually.
+To do so, you need to maintain the ``tempdirectory`` parameter described in
+``config.sample.php``
+
+As of writing, following external storage list uses temp files for up/download:
+
+* FTP
+* SMB / SMB_OC
+* WebDAV
+* Amazon S3
+* Dropbox
+* Google Drive
+* OpenStack SWIFT
+
+External storage list that uses direct file streaming:
+
+* Local
+* SFTP
+
 Backends
 --------
 

--- a/admin_manual/configuration_files/external_storage_configuration_gui.rst
+++ b/admin_manual/configuration_files/external_storage_configuration_gui.rst
@@ -76,6 +76,35 @@ You might need to setup a cron job that runs ``sudo -u www-data php occ files:sc
 to trigger a rescan of the user's files periodically (for example every 15 minutes), which includes
 the mounted external storage.
 
+Note regarding temporary disk space needs
+-----------------------------------------
+
+Not all external storage types are currently enabled for or do support streaming.
+Therefore ownCloud needs temporary space to buffer data for transfers. This can occur 
+when there are many concurrent users transferring data with a higher volume over a small 
+bandwidth wire. ownCloud may need in these cases an amount of temporary space which could 
+exeed the server capabilities. Example: 100 concurrent users uploading each a file having 
+300MB with a total transfer time of 6000s (1h 40min). The temporary space needed 
+by ownCloud for this period of time is 30GB. Even though it is not mandatory,
+the location of the temp directory used by ownCloud can be configured manually.
+To do so, you need to maintain the ``tempdirectory`` parameter described in
+``config.sample.php``
+
+As of writing, following external storage list uses temp files for up/download:
+
+* FTP
+* SMB / SMB_OC
+* WebDAV
+* Amazon S3
+* Dropbox
+* Google Drive
+* OpenStack SWIFT
+
+External storage list that uses direct file streaming:
+
+* Local
+* SFTP
+
 Local Storage
 -------------
 


### PR DESCRIPTION
@MorrisJobke, @carlaschroder 
This is a redo of #734 ("Note for external storage types that use temp space" ) which was already created but accidantally merged and needed to be reverted. 

**Do not merge before owncloud/core#13031 (Configurabe owncloud temporary directory)**

If the core PR gets merged, this one should be merged to finalize the documentation.

This PR documents that some external storage types may need a higher temporary disk space due to lack of steaming capabilities and references to a parameter to configure the temp dir location which is defined in core 13031

The note is written in configuration/external_storage_configuration gui and non gui version.