### PR TITLE
Update apps_management_installation.rst

### DIFF
--- a/admin_manual/installation/apps_management_installation.rst
+++ b/admin_manual/installation/apps_management_installation.rst
@@ -34,22 +34,18 @@ Adding Third Party Apps
 -----------------------
 
 Some apps are developed and supported by ownCloud directly, while other apps are created 
-by third parties and either included in or available for your ownCloud server 
-installation.  Any apps that are not developed by ownCloud show a *3rd party* 
-designation. Install unsupported apps at your own risk.
-
-Sometimes the installation of a third-party app fails silently, possibly because
-``'appcodechecker' => true,`` is enabled in ``config.php``. When ``appcodechecker`` is 
-enabled it checks if third-party apps are using the private API, rather than the public 
-API. If they are then they will not be installed. 
+by third parties and available for your ownCloud server installation.  Apps developed
+by the ownCloud community show a *recommended* designation. Any apps that are not
+developed by ownCloud but have been reviewed by the ownCloud security team show a 
+*3rd party* designation. Install unsupported apps at your own risk.
 
 To understand what an application does, you can click the app name to view a description 
 of the app and any of the app settings in the Application View field.  Clicking the 
-*Enable* button will enable the app.  If the app is a third party app, it will be 
-downloaded from the app store, installed and enabled.
+*Enable* button will enable the app.  If the app is not part of the ownCloud installation,
+it will be downloaded from the app store, installed and enabled. 
 
-Though ownCloud provides many apps in the server installation, you can view  more in
-the `ownCloud apps store <http://apps.owncloud.com/>`_.
+You can view new, unreviewed or unstable applications in the 
+`ownCloud apps store <http://apps.owncloud.com/>`_.
 
 To view or install apps from the ownCloud apps store:
 
@@ -69,6 +65,11 @@ installation, typically ``owncloud/apps``.
 access rights are **rwxr-x---**, or **0750** in octal notation, and the owner and group 
 are your HTTP user. On CentOS this is ``apache``, Ubuntu is ``www-data``, and on openSUSE 
 is it ``wwwrun:www``.
+
+Sometimes the installation of a third-party app fails silently, possibly because
+``'appcodechecker' => true,`` is enabled in ``config.php``. When ``appcodechecker`` is 
+enabled it checks if third-party apps are using the private API, rather than the public 
+API. If they are then they will not be installed. 
 
 .. note:: If you would like to create or add your own ownCloud app, please use the 
    *Add your App...* button on the same page. This button redirects you to our 


### PR DESCRIPTION
Update the application page documentation for ownCloud 8 - most apps are now no longer included. *recommended* applications are developed by the ownCloud community (and show up first) while *3rdparty* apps are developed by others (but those showing up by default are reviewed by the security team). Both are automatically downloaded and installed when you hit the 'enable' button

Not yet reviewed, new or unstable apps can, like today, be found on http://apps.owncloud.com and have to be manually installed.

**NOTE**: We have to make sure the distinction between these four categories is crystal clear:

* build in (always available)
* not build in but developed by ownCloud community: *recommended* (available but have to be downloaded from http://apps.owncloud.com)
* 3rd party, reviewed by our security team: *3rdparty* (available but have to be downloaded from http://apps.owncloud.com)
* 3rd party, not reviewed: *3rdparty* (but only after manual installation from a tarball, which you can find at http://apps.owncloud.com or other places)

We could simply apply this to the ownCloud 7 documentation too, it is equally correct.