### PR TITLE
Add SELinux note for remote databases

### DIFF
--- a/admin_manual/installation/selinux_configuration.rst
+++ b/admin_manual/installation/selinux_configuration.rst
@@ -34,3 +34,9 @@ HTTP server write access to these directories::
  /var/www/html/owncloud/config
  /var/www/html/owncloud/apps
 
+Allow access to a remote database
+---------------------------------
+
+An additional setting is needed if your installation is connecting to a remote database::
+
+ setsebool -P httpd_can_network_connect_db on


### PR DESCRIPTION
closes #784 , see also https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/6/html/Security-Enhanced_Linux/sect-Security-Enhanced_Linux-Booleans-Configuring_Booleans.html

Also relevant for stable7