### PR TITLE
updated google cloud console link

### DIFF
--- a/admin_manual/configuration/external_storage_configuration_gui.rst
+++ b/admin_manual/configuration/external_storage_configuration_gui.rst
@@ -185,7 +185,7 @@ Google Drive
 ------------
 
 All applications that access a Google API must be registered through the 
-`Google Cloud Console <https://cloud.google.com>`_. Follow along carefully 
+`Google Cloud Console <https://console.developers.google.com/>`_. Follow along carefully 
 because the Google is a bit of a maze and it's easy to get lost. 
 
 .. note:: Your ownCloud server must have a registered domain name and be 


### PR DESCRIPTION
I received an email from Florian Schulte that the google cloud console link in the current ownCloud 7 documentation is incorrect:

The old link, http://cloud.google.com/ seems to be for enterprise customers only these days, but https://console.developers.google.com/ matches the following documentation screenshots, so probably the link has changed.