### PR TITLE
Add note to enable the external user app before

### DIFF
--- a/admin_manual/configuration/user_auth_ftp_smb_imap.rst
+++ b/admin_manual/configuration/user_auth_ftp_smb_imap.rst
@@ -18,7 +18,9 @@ syntax:
       ),
   ),
 
-Currently the “External user support” (user_external) app provides the following user backends:
+Currently the “External user support” (user_external) app, which you need to
+enable first (See :doc:`../installation/apps_management_installation`)
+provides the following user backends:
 
 IMAP
 ----


### PR DESCRIPTION
Its still not clear for many users that the External user app needs to be activated before...

Should be also backported to stable7