### PR TITLE
Add anchor to documents troubleshooting

### DIFF
--- a/admin_manual/configuration/collaborative_documents_configuration.rst
+++ b/admin_manual/configuration/collaborative_documents_configuration.rst
@@ -36,7 +36,8 @@ installation a green ``Saved`` icon should appear.
 
 .. image:: ../images/documents_apply_test.png
 
-**Troubleshooting**
+Troubleshooting
+~~~~~~~~~~~~~~~
 
 If the mentioned test fails please make sure that:
 


### PR DESCRIPTION
Follow-up of https://github.com/owncloud/documentation/pull/833 to be able to directly link to the troubleshooting section within https://github.com/owncloud/core/pull/14074

Should be also backported to stable7