### PR TITLE
Remove .rst file ending from index.rst

### DIFF
--- a/admin_manual/configuration/index.rst
+++ b/admin_manual/configuration/index.rst
@@ -9,7 +9,7 @@ Configuration
    automatic_configuration
    background_jobs_configuration
    big_file_upload_configuration
-   collaborative_documents_configuration.rst
+   collaborative_documents_configuration
    config_sample_php_parameters
    custom_client_configuration
    database_configuration


### PR DESCRIPTION
Just cosmetic, but lets keep it in the same way as all other links.