### PR TITLE
Do not hardcode the database name

### DIFF
--- a/admin_manual/maintenance/backup.rst
+++ b/admin_manual/maintenance/backup.rst
@@ -35,5 +35,5 @@ PostgreSQL
 ^^^^^^^^^^
 ::
 
-    PGPASSWORD="password" pg_dump owncloud -h [server] -U [username] -f owncloud-sqlbkp_`date +"%Y%m%d"`.bak
+    PGPASSWORD="password" pg_dump [db_name] -h [server] -U [username] -f owncloud-sqlbkp_`date +"%Y%m%d"`.bak
 


### PR DESCRIPTION
The PostgreSQL database may not be called owncloud.
I propose to use [db_name] as for the MySQL command line.