### PR TITLE
rename mirall to client

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -349,7 +349,7 @@ Frequently Asked Questions
 .. _RST Cheat Sheet: http://github.com/ralsina/rst-cheatsheet/raw/master/rst-cheatsheet.pdf
 .. _reStructuredText Primer: http://sphinx-doc.org/rest.html
 .. _reStructuredText User Documentation: http://docutils.sourceforge.net/rst.html
-.. _own manual: https://github.com/owncloud/mirall/tree/master/doc
+.. _own manual: https://github.com/owncloud/client/tree/master/doc
 .. _Inkscape: http://www.inkscape.org
 .. _set up vim to spot unwanted spaces: http://vim.wikia.com/wiki/Highlight_unwanted_spaces
 .. _ownCloud mailinglist: mailto:owncloud@kde.org

--- a/developer_manual/bugtracker/index.rst
+++ b/developer_manual/bugtracker/index.rst
@@ -14,7 +14,7 @@ Thank you for helping ownCloud by reporting bugs. Before submitting an issue, pl
 `Issue submission guidelines`_ first.
 
 * If the issue is with the ownCloud server, report it to the `Core repository`_
-* If the issue is with the ownCloud client, report it to the `Mirall repository`_
+* If the issue is with the ownCloud client, report it to the `Client repository`_
 * If the issue with with an ownCloud app, report it to where that app is developed
 * If the app is listed in our `main github repository`_ report it to the correct sub 
   repository
@@ -27,6 +27,6 @@ Please note that the mailing list should not be used for bug reports, as it is h
 
 .. _Issue submission guidelines: https://github.com/owncloud/core/blob/master/CONTRIBUTING.md#submitting-issues
 .. _Core repository:  https://github.com/owncloud/core/issues
-.. _Mirall repository: https://github.com/owncloud/mirall/issues
+.. _Client repository: https://github.com/owncloud/client/issues
 .. _main github repository: https://github.com/owncloud
 .. _apps repository: https://github.com/owncloud/apps/issues

--- a/developer_manual/bugtracker/kanban.rst
+++ b/developer_manual/bugtracker/kanban.rst
@@ -11,7 +11,7 @@ Kanban Board = github issues + huboard
 --------------------------------------
 
 We are using http://huboard.com to visualize ownCloud github issues as a `kanban
-board`_ (see: `core`_, `apps`_, `mirall`_):
+board`_ (see: `core`_, `apps`_, `client`_):
 
 .. figure:: ../images/kanbanexample.png
    :scale: 70
@@ -274,7 +274,7 @@ Release.
 .. _mailing list: mailto:owncloud@kde.org
 .. _core: http://huboard.com/owncloud/core/board/#
 .. _apps: http://huboard.com/owncloud/apps/board/#
-.. _mirall: http://huboard.com/owncloud/mirall/board/#
+.. _client: http://huboard.com/owncloud/client/board/#
 .. _Gherkin: https://github.com/cucumber/cucumber/wiki/Gherkin
 .. _existing ones: https://ci.tmit.eu/job/acceptance-test/cucumber-html-reports/?
 .. _“Given … when … then …“: https://github.com/cucumber/cucumber/wiki/Given-When-Then

--- a/user_manual/files/files.rst
+++ b/user_manual/files/files.rst
@@ -356,7 +356,6 @@ Known Problems
 .. _in your file manager: http://en.wikipedia.org/wiki/Webdav#WebDAV_client_applications
 .. _ownCloud sync clients: http://doc.owncloud.org/desktop/1.7/
 .. _Mount ownCloud to a local folder without sync: http://owncloud.org/use/webdav/
-.. _ownCloud Mirall repository: https://github.com/owncloud/mirall
 .. _Android: http://github.com/owncloud/android
 .. _WebDAV Navigator: http://seanashton.net/webdav/
 .. _Android devices: https://play.google.com/store/apps/details?id=com.schimera.webdavnavlite


### PR DESCRIPTION
cc @danimo 

The one link I remove wasn't used in the document.