### PR TITLE
document that in case of php-fpm configurations, .user.ini must be used instead of .htaccess

### DIFF
--- a/admin_manual/configuration/big_file_upload_configuration.rst
+++ b/admin_manual/configuration/big_file_upload_configuration.rst
@@ -26,8 +26,10 @@ System Configuration
 Configuring Your Webserver
 --------------------------
 
-ownCloud comes with its own ``owncloud/.htaccess`` file. Set the following 
-two parameters inside this ``.htaccess`` file::
+| ownCloud comes with its own ``owncloud/.htaccess`` file.
+| If PHP-FPM is used, it can't read ``.htaccess`` PHP settings unless a PECL extension is installed. If PHP-FPM is used without the PECL extension installed, settings and permissions must be set in the ``owncloud/.user.ini`` file.
+
+Set the following two parameters inside the corresponding .ini file::
 
  php_value upload_max_filesize = 16G
  php_value post_max_size = 16G
@@ -41,7 +43,7 @@ increase the timeout values, which are in seconds::
 Configuring PHP
 ---------------
 
-If you don't want to use the ownCloud ``.htaccess`` file, you may 
+If you don't want to use the ownCloud ``.htaccess`` or ``.user.ini`` file, you may 
 configure PHP instead. Make sure to comment out any lines ``.htaccess`` 
 pertaining to upload size, if you entered any.
 
@@ -67,7 +69,7 @@ Tell PHP which temp file you want it to use::
  
  upload_tmp_dir = /var/big_temp_file/
 
-**Output Buffering** must be turned off in ``.htaccess`` or ``php.ini``, or PHP 
+**Output Buffering** must be turned off in ``.htaccess`` or ``.user.ini`` or ``php.ini``, or PHP 
 will return memory-related errors:
 
 * ``output_buffering = 0``

--- a/admin_manual/installation/nginx_configuration.rst
+++ b/admin_manual/installation/nginx_configuration.rst
@@ -99,3 +99,5 @@ Nginx Configuration
           /etc/php5/fpm/php.ini**) and increase **upload_max_filesize** and
           **post_max_size** values. You’ll need to restart php5-fpm and nginx
 	  services in order these changes to be applied.
+
+.. note:: ownCloud comes with its own ``owncloud/.htaccess`` file. If PHP-FPM is used, it can't read ``.htaccess`` PHP settings unless a PECL extension is installed. If PHP-FPM is used without the PECL extension installed, settings and permissions must be set in the ``owncloud/.user.ini`` file.

--- a/admin_manual/installation/source_installation.rst
+++ b/admin_manual/installation/source_installation.rst
@@ -325,7 +325,7 @@ Example config for Apache 2.4:
 * In order for the maximum upload size to be configurable, the
   :file:`.htaccess` in the ownCloud folder needs to be made writable by the
   server (this should already be done, see section ``Set the Directory 
-  Permissions``).
+  Permissions``). If PHP-FPM is used, it can't read ``.htaccess`` PHP settings unless a PECL extension is installed. If PHP-FPM is used without the PECL extension installed, settings and permissions must be set in the ``owncloud/.user.ini`` file.
 
 * You should make sure that any built-in WebDAV module of your web server is 
   disabled (at least for the ownCloud directory), as it will interfere with 


### PR DESCRIPTION
This is a followup of https://github.com/owncloud/documentation/issues/702 (Mention .user.ini every time .htaccess is mentioned)

ownCloud comes with its own ``owncloud/.htaccess`` file.
If PHP-FPM is used, it can't read ``.htaccess`` PHP settings unless a PECL extension is installed. If PHP-FPM is used without the PECL extension installed, settings and permissions must be set in the ``owncloud/.user.ini`` file.

The description above to use ``.user.ini`` instead of ``.htaccess`` was made in following documents:

- [x] [Uploading big files](https://github.com/owncloud/documentation/blob/master/admin_manual/configuration/big_file_upload_configuration.rst#enabling-uploading-big-files)
- [x] [Nginx Configuration](https://github.com/owncloud/documentation/blob/6c111c75dd4f443cdc162b647f347637e1ef34ec/admin_manual/installation/nginx_configuration.rst)
- [x] [Manual Installation from Source](https://github.com/owncloud/documentation/blob/0b2f4bd5d3dd03931b4282d399027af187f59d50/admin_manual/installation/source_installation.rst)