### PR TITLE
Sort all admin manual entries alphabetically

### DIFF
--- a/admin_manual/configuration/index.rst
+++ b/admin_manual/configuration/index.rst
@@ -5,35 +5,35 @@ Configuration
 .. toctree::
    :maxdepth: 2
 
-   antivirus_configuration
    automatic_configuration
-   background_jobs_configuration
-   big_file_upload_configuration
-   collaborative_documents_configuration
    config_sample_php_parameters
+   external_storage_configuration
+   external_storage_configuration_gui
+   server_to_server_configuration
+   antivirus_configuration
+   collaborative_documents_configuration
    custom_client_configuration
    database_configuration
+   background_jobs_configuration
    email_configuration
+   search_configuration
    encryption_configuration
-   external_storage_configuration_gui
-   external_storage_configuration
-   file_sharing_configuration
    files_locking_enabling
+   file_sharing_configuration
    js_css_asset_management_configuration
    knowledgebase_configuration
    language_configuration
+   user_auth_ldap_cleanup
    logging_configuration
-   occ_command
    performance_tips
    previews_configuration
+   reset_admin_password
    reverse_proxy_configuration
-   search_configuration
-   server_to_server_configuration
    serving_static_files_configuration
-   thirdparty_php_configuration
+   big_file_upload_configuration
    user_auth_ftp_smb_imap
    user_auth_ldap
-   user_auth_ldap_cleanup
    user_configuration
    user_provisioning_api
-   reset_admin_password
+   occ_command
+   thirdparty_php_configuration

--- a/admin_manual/index.rst
+++ b/admin_manual/index.rst
@@ -43,17 +43,17 @@ This section provides detailed instructions on how to install ownCloud in
 different scenarios.  It contains the following topics:
 
 * :doc:`installation/appliance_installation`
-* :doc:`installation/apps_management_installation`
-* :doc:`installation/hiawatha_configuration`
-* :doc:`installation/installation_wizard`
-* :doc:`installation/lighttpd_configuration`
 * :doc:`installation/linux_installation` (recommended)
 * :doc:`installation/macos_installation` (not supported)
-* :doc:`installation/nginx_configuration`
-* :doc:`installation/others_installation`
-* :doc:`installation/source_installation`
-* :doc:`installation/ucs_installation`
 * :doc:`installation/windows_installation`
+* :doc:`installation/source_installation`
+* :doc:`installation/installation_wizard`
+* :doc:`installation/ucs_installation`
+* :doc:`installation/others_installation`
+* :doc:`installation/apps_management_installation`
+* :doc:`installation/hiawatha_configuration`
+* :doc:`installation/lighttpd_configuration`
+* :doc:`installation/nginx_configuration`
 * :doc:`installation/yaws_configuration`
 * :doc:`installation/selinux_configuration`
 
@@ -66,38 +66,39 @@ Configuration
 This section describes how to configure ownCloud and your Web server.  It
 contains the following topics:
 
-* :doc:`configuration/antivirus_configuration`
 * :doc:`configuration/automatic_configuration`
-* :doc:`configuration/background_jobs_configuration`
-* :doc:`configuration/big_file_upload_configuration`
-* :doc:`configuration/collaborative_documents_configuration`
 * :doc:`configuration/config_sample_php_parameters`
+* :doc:`configuration/external_storage_configuration`
+* :doc:`configuration/external_storage_configuration_gui`
+* :doc:`configuration/server_to_server_configuration`
+* :doc:`configuration/antivirus_configuration`
+* :doc:`configuration/collaborative_documents_configuration`
 * :doc:`configuration/custom_client_configuration`
 * :doc:`configuration/database_configuration`
+* :doc:`configuration/background_jobs_configuration`
 * :doc:`configuration/email_configuration`
-* :doc:`configuration/external_storage_configuration_gui`
-* :doc:`configuration/external_storage_configuration`
-* :doc:`configuration/file_sharing_configuration`
+* :doc:`configuration/search_configuration`
+* :doc:`configuration/encryption_configuration`
 * :doc:`configuration/files_locking_enabling`
+* :doc:`configuration/file_sharing_configuration`
 * :doc:`configuration/js_css_asset_management_configuration`
 * :doc:`configuration/knowledgebase_configuration`
 * :doc:`configuration/language_configuration`
+* :doc:`configuration/user_auth_ldap_cleanup`
 * :doc:`configuration/logging_configuration`
-* :doc:`configuration/occ_command`
 * :doc:`configuration/performance_tips`
 * :doc:`configuration/previews_configuration`
+* :doc:`configuration/reset_admin_password`
 * :doc:`configuration/reverse_proxy_configuration`
-* :doc:`configuration/search_configuration`
-* :doc:`configuration/encryption_configuration`
-* :doc:`configuration/server_to_server_configuration`
 * :doc:`configuration/serving_static_files_configuration`
-* :doc:`configuration/thirdparty_php_configuration`
+* :doc:`configuration/big_file_upload_configuration`
 * :doc:`configuration/user_auth_ftp_smb_imap`
 * :doc:`configuration/user_auth_ldap`
-* :doc:`configuration/user_auth_ldap_cleanup`
 * :doc:`configuration/user_configuration`
 * :doc:`configuration/user_provisioning_api`
-* :doc:`configuration/reset_admin_password`
+* :doc:`configuration/occ_command`
+* :doc:`configuration/thirdparty_php_configuration`
+
 
 Maintenance
 ===========

--- a/admin_manual/installation/index.rst
+++ b/admin_manual/installation/index.rst
@@ -12,10 +12,10 @@ Installation
    installation_wizard
    lighttpd_configuration
    macos_installation
+   source_installation
    nginx_configuration
    others_installation
-   source_installation
+   selinux_configuration
    ucs_installation
    windows_installation
    yaws_configuration
-   selinux_configuration

--- a/admin_manual/maintenance/index.rst
+++ b/admin_manual/maintenance/index.rst
@@ -5,11 +5,11 @@ Maintenance
 .. toctree::
    :maxdepth: 2
 
-   enable_maintenance
    backup
+   convert_db
+   enable_maintenance
+   migrating
+   restore
    update
    upgrade
-   restore
-   migrating
-   convert_db
 


### PR DESCRIPTION
So that users can find them easier.

This sorts them not as filenames, but as their titles.