### PR TITLE
Add description / link that self-signed certs needs to be imported

### DIFF
--- a/admin_manual/configuration/external_storage_configuration.rst
+++ b/admin_manual/configuration/external_storage_configuration.rst
@@ -39,6 +39,13 @@ values need to be concatenated and written in a row without these modifications!
 It is recommended to use the :doc:`Web-GUI <external_storage_configuration_gui>` in the
 administrator panel to add, remove or modify mount options to prevent any problems!
 
+Using self-signed certificates
+------------------------------
+
+When using self-signed certificates for external storage mounts the certificate
+needs to be imported in the personal settings of the user. Please refer to `this <http://ownclouden.blogspot.de/2014/11/owncloud-https-external-mount.html>`_
+blogpost for more informations.
+
 Example
 -------
 

--- a/admin_manual/configuration/external_storage_configuration_gui.rst
+++ b/admin_manual/configuration/external_storage_configuration_gui.rst
@@ -51,6 +51,13 @@ external storage services, and check the services you want to allow.
 After creating your external storage mounts, you can share them and control 
 permissions just like any other ownCloud share.
 
+Using self-signed certificates
+------------------------------
+
+When using self-signed certificates for external storage mounts the certificate
+needs to be imported in the personal settings of the user. Please refer to `this <http://ownclouden.blogspot.de/2014/11/owncloud-https-external-mount.html>`_
+blogpost for more informations.
+
 Local Storage
 -------------
 

--- a/admin_manual/configuration/server_to_server_configuration.rst
+++ b/admin_manual/configuration/server_to_server_configuration.rst
@@ -39,6 +39,13 @@ Un-check the ``Share Link`` checkbox to disable the share.
 See "Using Server-to-Server Sharing" in the Users Manual to learn how to 
 connect to a remote public share.
 
+Using self-signed certificates
+------------------------------
+
+When using self-signed certificates for server-to-server sharing the certificate
+needs to be imported in the personal settings of the user. Please refer to `this <http://ownclouden.blogspot.de/2014/11/owncloud-https-external-mount.html>`_
+blogpost for more informations.
+
 Notes
 --------
 


### PR DESCRIPTION
Ref: https://github.com/owncloud/documentation/issues/115. Starting with OC8 self-signed certs could be also imported for server-2-server sharing.

Could be also useful to directly include the description from the blogpost into the OC docs.