### PR TITLE
Jospoortvliet patch 2

### DIFF
--- a/index/index.rst
+++ b/index/index.rst
@@ -2,13 +2,15 @@
 Documentation Overview
 ======================
 
----------------
-ownCloud Videos
----------------
+------------------
+ownCloud Resources
+------------------
 
-`Howtos, demos, news, and Webinars 
+* `Howtos, demos, news, and Webinars 
 <https://doc.owncloud.org/server/8.0/admin_manual/videos/index.html>`_ for both the 
 Server and Enterprise versions of ownCloud.
+* `ownCloud FAQ <https://owncloud.org/eight>`_ with answers around the ownCloud community, technology and more.
+* `Where to get help <https://owncloud.org/faq/#channels>`_ when the documentation is not enough.
 
 --------------------
 ownCloud Server 8.0

--- a/index/index.rst
+++ b/index/index.rst
@@ -7,8 +7,8 @@ ownCloud Resources
 ------------------
 
 * `Howtos, demos, news, and Webinars 
-<https://doc.owncloud.org/server/8.0/admin_manual/videos/index.html>`_ for both the 
-Server and Enterprise versions of ownCloud.
+  <https://doc.owncloud.org/server/8.0/admin_manual/videos/index.html>`_ for both the 
+  Server and Enterprise versions of ownCloud.
 * `ownCloud FAQ <https://owncloud.org/eight>`_ with answers around the ownCloud community, technology and more.
 * `Where to get help <https://owncloud.org/faq/#channels>`_ when the documentation is not enough.
 


### PR DESCRIPTION
I'd like to more prominently point to the FAQ and other resources like Forums, IRC and mailing list and this seems a decent place to do it in. I could spell out the ML, IRC and forum links in here but I think the link to the FAQ there is better - what do others think?

Also - "Where to get help when the documentation is not enough" might not be the best wording. Suggestions on improvements?