### PR TITLE
Add note for missing large files support on Windows PHP

### DIFF
--- a/admin_manual/configuration_files/big_file_upload_configuration.rst
+++ b/admin_manual/configuration_files/big_file_upload_configuration.rst
@@ -7,6 +7,7 @@ limit up to what your filesystem and operating system allows. There are certain
 hard limits that cannot be exceeded:
 
 * < 2GB on 32Bit OS-architecture
+* < 2GB on Windows (32Bit and 64Bit)
 * < 2GB with Server Version 4.5 or older
 * < 2GB with IE6 - IE8
 * < 4GB with IE9 - IE10


### PR DESCRIPTION
> x86_64 Builds
>
> The x64 builds of PHP for Windows should be considered experimental, and do not yet provide 64-bit > integer or large file support. Please see this post for work ongoing to improve these builds.

Source: http://windows.php.net/download/