### PR TITLE
Added --dir directive since default path is core

### DIFF
--- a/developer_manual/general/devenv.rst
+++ b/developer_manual/general/devenv.rst
@@ -55,7 +55,7 @@ After the development tool installation make the directory writable::
   
 Then install ownCloud from git::
 
-  ocdev setup base
+  ocdev setup --dir /var/www base
 
 Adjust rights::
 

--- a/developer_manual/general/devenv.rst
+++ b/developer_manual/general/devenv.rst
@@ -55,7 +55,9 @@ After the development tool installation make the directory writable::
   
 Then install ownCloud from git::
 
-  ocdev setup --dir /var/www base
+  ocdev setup --dir /var/www/<folder> base
+
+where <folder> is the folder where you want to install ownCloud.
 
 Adjust rights::
 


### PR DESCRIPTION
The example is stating that /var/www will be used as the location where ownCloud is installed, so we need to make sure that the command matches the description