### PR TITLE
Use closure and non-deprecated methods for navigation entry

### DIFF
--- a/developer_manual/app/init.rst
+++ b/developer_manual/app/init.rst
@@ -10,35 +10,37 @@ The :file:`appinfo/app.php` is the first file that is loaded and executed in own
     
     <?php
 
-    \OCP\App::addNavigationEntry(array(
+    \OC::$server->getNavigationManager()->add(function () {
+        $urlGenerator = \OC::$server->getURLGenerator();
+        return [
+            // the string under which your app will be referenced in owncloud
+            'id' => 'myapp',
 
-        // the string under which your app will be referenced in owncloud
-        'id' => 'myapp',
+            // sorting weight for the navigation. The higher the number, the higher
+            // will it be listed in the navigation
+            'order' => 10,
 
-        // sorting weight for the navigation. The higher the number, the higher
-        // will it be listed in the navigation
-        'order' => 10,
+            // the route that will be shown on startup
+            'href' => $urlGenerator->linkToRoute('myapp.page.index'),
 
-        // the route that will be shown on startup
-        'href' => \OCP\Util::linkToRoute('myapp.page.index'),
+            // the icon that will be shown in the navigation
+            // this file needs to exist in img/
+            'icon' => $urlGenerator->imagePath('myapp', 'app.svg'),
 
-        // the icon that will be shown in the navigation
-        // this file needs to exist in img/example.png
-        'icon' => \OCP\Util::imagePath('myapp', 'app.svg'),
-
-        // the title of your application. This will be used in the
-        // navigation or on the settings page of your app
-        'name' => \OC_L10N::get('myapp')->t('My App')
-    ));
+            // the title of your application. This will be used in the
+            // navigation or on the settings page of your app
+            'name' => \OC::$server->getL10N('myapp')->t('My App'),
+        ];
+    });
 
     // execute OCA\MyApp\BackgroundJob\Task::run when cron is called
-    \OCP\Backgroundjob::addRegularTask('OCA\MyApp\BackgroundJob\Task', 'run');
+    \OC::$server->getJobList()->add('OCA\MyApp\BackgroundJob\Task');
 
     // execute OCA\MyApp\Hooks\User::deleteUser before a user is being deleted
     \OCP\Util::connectHook('OC_User', 'pre_deleteUser', 'OCA\MyApp\Hooks\User', 'deleteUser');
 
 
-It is also possible to include :doc:`js` or :doc:`css` for other apps by placing the **addScript** or **addStyle** functions inside this file.
+Although it is also possible to include :doc:`js` or :doc:`css` for other apps by placing the **addScript** or **addStyle** functions inside this file, it is strongly discouraged, because the file is loaded on each request (also such requests that do not return HTML, but e.g. json or webdav).
 
 .. code-block:: php
     


### PR DESCRIPTION
- [x] Use a closure for the navigation entry: https://mailman.owncloud.org/pipermail/devel/2015-March/001146.html
- [x] Do not use deprecated/internal methods `\OCP\Util::linkToRoute()` && `\OCP\Util::linkToRoute()`
- [x] Do not use deprecated `\OCP\Backgroundjob::addRegularTask()`
- [x] Discourage loading JS and CSS in the app.php file

@LukasReschke please review
@carlaschroder 