### PR TITLE
Don't move folders of packages after installation.

### DIFF
--- a/admin_manual/installation/linux_installation.rst
+++ b/admin_manual/installation/linux_installation.rst
@@ -27,6 +27,9 @@ repository, download and install the repository signing key, and install
 ownCloud. Then run the Installation Wizard to complete your installation. (see 
 :doc:`installation_wizard`).
 
+.. note:: Please don't move the folders provided by this packages after the installation.
+   This will break further updates.
+
 If your distribution is not listed, your Linux distribution may maintain its own 
 ownCloud packages, or you may prefer to install from source code (see 
 :doc:`source_installation`).


### PR DESCRIPTION
Still happens quite often (e.g. https://github.com/owncloud/core/issues/12732 or https://forum.owncloud.org/viewtopic.php?f=29&t=26318&p=82985#p82985) that people move the /var/www/owncloud folder to another place and wonder why they don't get updates anymore.