### PR TITLE
Update config_sample_php_parameters.rst

### DIFF
--- a/admin_manual/configuration_server/config_sample_php_parameters.rst
+++ b/admin_manual/configuration_server/config_sample_php_parameters.rst
@@ -885,7 +885,7 @@ Miscellaneous
 	'blacklisted_files' => array('.htaccess'),
 
 Blacklist a specific file or files and disallow the upload of files
-with this name. ``.htaccess`` is blocked by default.
+with this name. Use only lower case. ``.htaccess`` is blocked by default.
 
 WARNING: USE THIS ONLY IF YOU KNOW WHAT YOU ARE DOING.
 


### PR DESCRIPTION
Added the information, that blacklisted_files need to be lower case. 
See https://github.com/owncloud/core/blob/master/lib/private/files/filesystem.php#L542