### PR TITLE
link to support page on index and community YT and .com resources page o...

### DIFF
--- a/admin_manual/videos/index.rst
+++ b/admin_manual/videos/index.rst
@@ -2,9 +2,17 @@
 ownCloud Videos
 ===============
 
-Please visit our `YouTube channel 
-<https://www.youtube.com/user/ownCloudofficial/>`_ for howtos, demos, news, and 
-Webinars for both the Server and Enterprise versions of ownCloud.
+Please visit the `owncloud.com YouTube channel
+<https://www.youtube.com/user/ownCloudofficial/>`_ for howtos, demos, news, and Webinars
+for both the Server and Enterprise versions of ownCloud.
+
+The `ownclouders communty YouTube channel <https://www.youtube.com/user/ownclouders/>`_
+gathers howtos and tutorials from all over the
+web `in this playlist
+<https://www.youtube.com/watch?v=NNfWIme5sFc&list=PLtZe22ggl2YBi1u2dH0qg9fgnym5DwYbW>`_.
+
+You can find `more webinars, white papers and other resources on owncloud.com.
+<https://owncloud.com/resources/>`_
 
 Server to Server Sharing on ownCloud 7
 --------------------------------------

--- a/index/index.rst
+++ b/index/index.rst
@@ -11,7 +11,7 @@ Additional ownCloud Resources
 * `What's New in ownCloud 8 
   <https://owncloud.org/eight>`_ Video introduction to ownCloud 8.
 * `Where to get help 
-  <https://owncloud.org/faq/>`_ when the documentation is not enough.
+  <https://owncloud.org/support/>`_ when the documentation is not enough.
  
 ------------
 ownCloud 8.1


### PR DESCRIPTION
...n videos page

The .com youtube channel doesn't have that many videos, the ownClouders account is overloaded with 'em :dancers: 

And support replaces the faq page as place for finding where to get help.