### PR TITLE
fix links to social media and .com site

### DIFF
--- a/_shared_assets/themes/owncloud_com/layout.html
+++ b/_shared_assets/themes/owncloud_com/layout.html
@@ -114,9 +114,9 @@
 
 <div class="follow">
 <p><a class="visible" href="https://owncloud.com" title="ownCloud">Back to owncloud.com</a>|<span class="visible">Follow us:</span></p>  
-<a class="twitter" href="https://twitter.com/#!/owncloudcom" target="_blank">Twitter</a>
+<a class="twitter" href="https://twitter.com/ownloud" target="_blank">Twitter</a>
 <a class="facebook" href="http://www.facebook.com/owncloud" target="_blank">Facebook</a>
-<a class="google" href="https://plus.google.com/b/102805591550379137055/" target="_blank">Google</a>
+<a class="google" href="https://plus.google.com/+OwncloudOfficial" target="_blank">Google</a>
 </div>
 
 </div>
@@ -169,7 +169,7 @@
   	<ul id="menu-footer-navigation" class="menu">
   		<li><a href="https://owncloud.com">Home</a></li>
   		<li><a href="https://owncloud.com/about">About ownCloud</a></li>
-  		<li><a href="https://owncloud.com/event/events">Events</a></li>
+  		<li><a href="https://owncloud.com/resources">Resources</a></li>
   		<li><a href="https://owncloud.com/become-partner">Become a Partner</a></li>
   		<li><a href="https://owncloud.org">Community</a></li>
   		<li><a href="https://owncloud.com/blog">Blog</a></li>
@@ -180,9 +180,9 @@
   
   <div class="follow_f">
   	<ul>
-  		<li><a class="twitter" target="_blank" href="https://twitter.com/#!/owncloudcom">Twitter</a></li>
-  		<li><a class="facebook" target="_blank" href="http://www.facebook.com/owncloud">Facebook</a></li>
-  		<li><a class="google" target="_blank" href="https://plus.google.com/b/102805591550379137055/">Google</a></li>
+  		<li><a class="twitter" href="https://twitter.com/ownloud" target="_blank">Twitter</a></li>
+  		<li><a class="facebook" href="http://www.facebook.com/owncloud" target="_blank">Facebook</a></li>
+  		<li><a class="google" href="https://plus.google.com/+OwncloudOfficial" target="_blank">Google</a></li>
   	</ul>
   </div>
   


### PR DESCRIPTION
don't even think about clicking the current twitter link... Actually links to an evil spammer...
And the events link went to a 404.

Now, it should all work - pretty trivial fixes, actually.