### PR TITLE
Add note how to get the input box shown.

### DIFF
--- a/admin_manual/configuration/configuring_big_file_upload.rst
+++ b/admin_manual/configuration/configuring_big_file_upload.rst
@@ -30,6 +30,10 @@ Enabling uploading big files
 * Under "File handling" set the Maximum upload size to the desired value (e.g. 16GB)
 * Click the "save"-Button
 
+.. note:: This input box is only shown if your webserver has write access to your
+   ``.htaccess`` file and the ``AllowOverride ALL`` directive is set in your
+   webservers vhost configuration. It is also not shown on non-Apache webservers.
+
 **Configuring your webserver**
 
 ownCloud comes with a .htaccess - file which propagates all config to your webserver. To adapt those settings go to the ownCloud - Folder on your server and set the following two parameters inside the .htaccess file:


### PR DESCRIPTION
Fixes #523

stable7+ is not affected as it don't contain this text in the big file upload docs. OC 8.1 will also always shown the input box with https://github.com/owncloud/core/pull/14133