### PR TITLE
update conf.py with morefloats to build pdfs with more than 18 images

### DIFF
--- a/admin_manual/conf.py
+++ b/admin_manual/conf.py
@@ -172,7 +172,10 @@ htmlhelp_basename = 'ownCloudServerAdminManual'
 
 # -- Options for LaTeX output --------------------------------------------------
 
-latex_elements = {
+latex_elements = {'preamble': '\usepackage{morefloats}'
+}
+
+# latex_elements = {
 # The paper size ('letterpaper' or 'a4paper').
 #'papersize': 'letterpaper',
 
@@ -180,8 +183,7 @@ latex_elements = {
 #'pointsize': '10pt',
 
 # Additional stuff for the LaTeX preamble.
-'preamble': '\usepackage{morefloats}'
-}
+# }
 
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title, author, documentclass [howto/manual]).


### PR DESCRIPTION
allrightythen, testing to see if editing conf.py give mr jenkins what he needs to build PDFs with more than 18 images.

re https://github.com/owncloud/documentation/issues/1139