### PR TITLE
Replace 'js' by 'css' in CSS Documentation

### DIFF
--- a/developer_manual/app/css.rst
+++ b/developer_manual/app/css.rst
@@ -10,10 +10,10 @@ The CSS files reside in the **css/** folder and should be included in the templa
 
   <?php
   // include one file
-  style('myapp', 'style');  // adds js/style.css
+  style('myapp', 'style');  // adds css/style.css
 
   // include multiple files for the same app
-  style('myapp', array('style', 'navigation'));  // adds js/style.css, js/navigation.css
+  style('myapp', array('style', 'navigation'));  // adds css/style.css, css/navigation.css
 
   // include vendor file (also allows vendor syntax)
   vendor_style('myapp', 'style');  // adds vendor/style.css


### PR DESCRIPTION
Probably a copy paste error from the js documentation.

Maybe
```
vendor_style('myapp', 'style');  // adds vendor/style.css
```
should be replaced by
```
vendor_style('myapp', 'style');  // adds css/vendor/style.css
```
as well!?