### PR TITLE
Added a note to disable AdBlock

### DIFF
--- a/user_manual/pim/calendar.rst
+++ b/user_manual/pim/calendar.rst
@@ -35,6 +35,8 @@ The Calendar app contains the following fields and controls:
   controls include sharing, obtaining an external URL link to the calendar, an
   export function, an edit function, and a delete (trash) button.
 
+  .. note:: Some Ad-Block plugins hide the "Share" button for calendars. If the "Share" button is missing, try disabling your Ad-Block plugin or add a whitelist-entry for your OwnCloud instance.
+
 - Calendar Settings -- Provides access to the calendar-specific settings.  These
   settings include the calendar timezone selection, time format selection, week
   start day, cache setting, primary CalDAV address, and iOS/OS X CalDAV address


### PR DESCRIPTION
Added a note to disable AdBlock when the Share-Button for calendars is missing.

See owncloud/calendar#747 , owncloud/calendar#679 , owncloud/calendar#713 , owncloud/calendar#661, owncloud/calendar#794