### PR TITLE
Migration: data files' timestamp should be kept

### DIFF
--- a/admin_manual/maintenance/migrating.rst
+++ b/admin_manual/maintenance/migrating.rst
@@ -48,13 +48,15 @@ the new location. It is also assumed that the authentication method
     import it in the database.
 
 
-#.  Copy all files from your ownCloud instance, the ownCloud program files,
-    the data files, the log files and the configuration files, to the new
-    machine. Depending on the original installation method and the OS the
-    files are located in different locations. On the new system make sure to
-    pick the appropriate locations. If you change any paths, make sure to
-    adopt the paths in the ownCloud config.php file. Note: This step might
-    take several hours, depending on your installation.
+#.  Copy all files from your ownCloud instance, the ownCloud program files, the
+    data files, the log files and the configuration files, to the new
+    machine. The data files should keep their original timestamp (can be done by
+    using ``rsync`` with ``-t`` option) otherwise the clients will re-download
+    all the files after the migration. Depending on the original installation
+    method and the OS the files are located in different locations. On the new
+    system make sure to pick the appropriate locations. If you change any paths,
+    make sure to adopt the paths in the ownCloud config.php file. Note: This
+    step might take several hours, depending on your installation.
 
 
 #.  While still having ownCloud in maintenance mode (confirm!) and **BEFORE**


### PR DESCRIPTION
Currently the migration doc only mentioned copying data files to the new
machine. However, if the data files are copied naively, all the clients
will redownload all the files after the migration is done. The migration
doc should mention this point.