### PR TITLE
add header security directives for nginx (see core #15342)

### DIFF
--- a/admin_manual/configuration_server/harden_server.rst
+++ b/admin_manual/configuration_server/harden_server.rst
@@ -145,13 +145,16 @@ However, these headers are added by the applications code in PHP and thus not
 served on static resources and rely on the fact that there is no way to bypass 
 the intended response code path.
 
-For optimal security administrators are encouraged to serve these basic HTTP 
-headers by the web server to enforce them on response. To do this Apache has to 
-be configured to use the ``.htaccess`` file as well as the following Apache 
+For optimal security, administrators are encouraged to serve these basic HTTP 
+headers by the web server to enforce them on response.
+
+Apache has to be configured to use the ``.htaccess`` file as well as the following Apache 
 modules needs to be enabled:
 
 - mod_headers
 - mod_env
+
+For nginx, please see the nginx configuration example :ref:`nginx_configuration_example`
 
 Administrators can verify whether this security change is active by accessing a 
 static resource served by the web server and verify that above mentioned 

--- a/admin_manual/installation/nginx_configuration.rst
+++ b/admin_manual/installation/nginx_configuration.rst
@@ -1,3 +1,4 @@
+.. _nginx_configuration_example:
 Nginx Configuration
 ===================
 
@@ -33,6 +34,13 @@ Nginx Configuration
 
     ssl_certificate /etc/ssl/nginx/cloud.example.com.crt;
     ssl_certificate_key /etc/ssl/nginx/cloud.example.com.key;
+
+    # Add headers to serve security related headers
+    add_header Strict-Transport-Security "max-age=15768000; includeSubDomains; preload;";
+    add_header X-Content-Type-Options nosniff;
+    add_header X-Frame-Options "SAMEORIGIN";
+    add_header X-XSS-Protection "1; mode=block";
+    add_header X-Robots-Tag none;
 
     # Path to the root of your installation
     root /var/www/owncloud/;


### PR DESCRIPTION
This PR adds the "add header" directives to the nginx configuration example
https://github.com/owncloud/documentation/blob/master/admin_manual/installation/nginx_configuration.rst
and also adds a note to
https://github.com/owncloud/documentation/blob/master/admin_manual/configuration_server/harden_server.rst#serve-security-related-headers-by-the-web-server 
for nginx.

Reason: https://github.com/owncloud/core/issues/15342 has been fixed, and with this PR it is now easier to implement the directives needed for nginx