### PR TITLE
add note that encryption can't be disabled anymore

### DIFF
--- a/admin_manual/release_notes.rst
+++ b/admin_manual/release_notes.rst
@@ -68,7 +68,7 @@ enable the new encryption backend and migrate your encryption keys. See
 :doc:`configuration_files/encryption_configuration`
 
 Encryption can no longer be disabled in ownCloud 8.1. It is planned to re-add
-this feature to the command line client for the 8.2 release.
+this feature to the command line client for a future release.
 
 Due to various technical issues, by default desktop sync clients older than 
 1.7 are not allowed to connect and sync with the ownCloud server. This is 

--- a/admin_manual/release_notes.rst
+++ b/admin_manual/release_notes.rst
@@ -66,7 +66,10 @@ requests.
 When you upgrade from ownCloud 8.0, with encryption enabled, to 8.1, you must 
 enable the new encryption backend and migrate your encryption keys. See 
 :doc:`configuration_files/encryption_configuration`
-  
+
+Encryption can no longer be disabled in ownCloud 8.1. It is planned to re-add
+this feature to the command line client for the 8.2 release.
+
 Due to various technical issues, by default desktop sync clients older than 
 1.7 are not allowed to connect and sync with the ownCloud server. This is 
 configurable via the ``minimum.supported.desktop.version`` switch in 

--- a/user_manual/files/encrypting_files.rst
+++ b/user_manual/files/encrypting_files.rst
@@ -80,21 +80,6 @@ restore your files if you lose your login password.
 
 .. figure:: ../images/encryption3.png
 
-Removing Encryption
--------------------
-
-If your ownCloud administrator elects to disable the Encryption app, you will 
-be prompted to go to your Personal page and enter your password on the 
-Encryption form to decrypt your files.
-
-.. figure:: ../images/encryption4.png
-
-If your files decrypt successfully, you can click the ``Delete encryption 
-keys`` button. There is no reason to save them after disabling decryption, 
-because if encryption is enabled again you'll generate a new set of keys. Your 
-keys are preserved in case something goes wrong with the decryption and you 
-need your keys to access your files.
-
 Files Not Encrypted
 -------------------
 


### PR DESCRIPTION
@karlitschek @schiesbn @carlaschroder simple addition:

----

Encryption can no longer be disabled in ownCloud 8.1. It is planned to re-add this feature to the command line client for the 8.2 release.

----

Do we want to be explicit about the 8.2 release or just say "for a future release"?