### PR TITLE
Change somaxconn and backlog values to 65535

### DIFF
--- a/admin_manual/configuration_server/performance_tuning.rst
+++ b/admin_manual/configuration_server/performance_tuning.rst
@@ -106,8 +106,8 @@ Configuration for more concurrent requests.
 	echo "1" > /proc/sys/net/ipv4/tcp_tw_reuse
 	echo "10" > /proc/sys/net/ipv4/tcp_fin_timeout
 
-	echo "65536" > /proc/sys/net/core/somaxconn
-	echo "65536" > /proc/sys/net/ipv4/tcp_max_syn_backlog
+	echo "65535" > /proc/sys/net/core/somaxconn
+	echo "65535" > /proc/sys/net/ipv4/tcp_max_syn_backlog
 	echo "262144" > /proc/sys/net/netfilter/nf_conntrack_max
 
 Check if the values have been set accordingly:
@@ -123,9 +123,9 @@ Check if the values have been set accordingly:
 	# cat /proc/sys/net/ipv4/tcp_fin_timeout
         10
 	# cat /proc/sys/net/core/somaxconn
-        65536
+        65535
 	# cat /proc/sys/net/ipv4/tcp_max_syn_backlog
-        65536
+        65535
 	# cat /proc/sys/net/netfilter/nf_conntrack_max
         262144
 
@@ -136,8 +136,8 @@ Next, persist the settings across reboots by adding them into ``/etc/sysctl.conf
 	net.ipv4.tcp_tw_reuse = 1
 	net.ipv4.tcp_fin_timeout = 10
 
-	net.core.somaxconn = 65536
-	net.ipv4.tcp_max_syn_backlog = 65536
+	net.core.somaxconn = 65535
+	net.ipv4.tcp_max_syn_backlog = 65535
 	net.netfilter.nf_conntrack_max = 262144
 
 Tuning Memory


### PR DESCRIPTION
The value of `somaxconn` is a `ushort` in the kernel and will throw an error if the value is above 65535 instead of silently truncating it. The value of `tcp_max_syn_backlog` should also be equal to or less than the value of `somaxconn` as pointed out here:

http://stackoverflow.com/questions/1198564/programatically-evaluating-the-value-of-somaxconn-to-set-the-listen-backlog-par

Original issue is here:

https://github.com/owncloud/documentation/issues/1293