### PR TITLE
fix occ encryption command

### DIFF
--- a/admin_manual/configuration_files/encryption_configuration.rst
+++ b/admin_manual/configuration_files/encryption_configuration.rst
@@ -237,11 +237,11 @@ strongly recommend using the ``occ`` command; the **Start Migration** button is
 for admins who do not have access to the console, for example installations on 
 shared hosting. This example is for Debian/Ubuntu Linux::
 
- $ sudo -u www-data php occ encryption:migrate-keys
+ $ sudo -u www-data php occ encryption:migrate
  
 This example is for Red Hat/CentOS/Fedora Linux::
 
- $ sudo -u apache php occ encryption:migrate-keys 
+ $ sudo -u apache php occ encryption:migrate
  
 You must run ``occ`` as your HTTP user; see 
 :doc:`../configuration_server/occ_command`.


### PR DESCRIPTION
the correct encryption command is ````occ encryption:migrate```` not ````occ encryption:migrate-keys```` for ownCloud 8.1

cc  @carlaschroder please review and merge, thanks!