### PR TITLE
added note about different php versions.

### DIFF
--- a/admin_manual/configuration_server/occ_command.rst
+++ b/admin_manual/configuration_server/occ_command.rst
@@ -29,6 +29,12 @@ The HTTP user is different on the various Linux distributions. See
 * The HTTP user and group in Arch Linux is http.
 * The HTTP user in openSUSE is wwwrun, and the HTTP group is www.   
 
+
+If your HTTP server is configured to use a different php version than the default (/usr/bin/php), occ should be run with the same version. Example: In CentOS 6.5 with SCL-PHP54 installed, the command looks like this::
+
+  $ sudo -u apache /opt/rh/php54/root/usr/bin/php /var/www/html/owncloud/occ ...
+
+
 Running it with no options lists all commands and options, like this example on 
 Ubuntu::
 


### PR DESCRIPTION
This applies to all redhat and centos versions, where the admin used software collections or rhn-channels to upgrde their php version. They end up having two, the original php  still lingering as a default in /usr/bin/php and the new php version somewhat hidden in /opt/rh/...