### PR TITLE
A missing memcache causes unavailability of the ownCloud instance

### DIFF
--- a/admin_manual/configuration_server/performance_tuning.rst
+++ b/admin_manual/configuration_server/performance_tuning.rst
@@ -101,6 +101,13 @@ Distributed PHP environments should use Memcached. Memcached servers must be
 specified in the ``memcached_servers`` array in ownCloud's config file 
 ``config.php``. For examples see :doc:`config_sample_php_parameters`.
 
+ .. note:: When a memory cache has been configured, but is unavailable due to a
+           a missing extension or server downtime, ownCloud will be
+           inaccessible, as a memory cache is considered to be a vital
+           component.
+           This does not however affect **occ**, which will instead just print
+           a warning to the logs.
+
 Tuning System Parameters
 ========================
 


### PR DESCRIPTION
While the log errors are quite obvious about this, it's best to document this under the relevant section to avoid any potential confusion

cc @PVince81 @nickvergessen 