### PR TITLE
[stable8.1] A missing memcache causes unavailability of the ownCloud instance

### DIFF
--- a/admin_manual/configuration_server/performance_tuning.rst
+++ b/admin_manual/configuration_server/performance_tuning.rst
@@ -101,6 +101,11 @@ Distributed PHP environments should use Memcached. Memcached servers must be
 specified in the ``memcached_servers`` array in ownCloud's config file 
 ``config.php``. For examples see :doc:`config_sample_php_parameters`.
 
+ .. note:: When a memory cache has been configured, but is unavailable due to a
+           a missing extension or server downtime, ownCloud will be
+           inaccessible, as a memory cache is considered to be a vital
+           component.
+
 Tuning System Parameters
 ========================
 


### PR DESCRIPTION
Backport of #1365 

This behaviour was introduced with ownCloud 8.1. The text is the same apart from the bit about `occ`, which was changed in master recently and so doesn't apply to 8.1.

cc @PVince81 @nickvergessen 