### PR TITLE
SELinux for sendmail and external storages

### DIFF
--- a/admin_manual/configuration_files/external_storage_configuration.rst
+++ b/admin_manual/configuration_files/external_storage_configuration.rst
@@ -33,6 +33,9 @@ available for use:
    can use the examples below. See the section :doc:`external_storage_configuration_gui`
    how to do this.
 
+.. note:: A non-blocking or correctly configured SELinux setup is needed
+   for these backends to work. Please refer to the :ref:`selinux-config-label`.
+
 Please keep in mind that some formatting has been applied and carriage returns
 have been added for better readability. In the :file:`data/mount.json` all
 values need to be concatenated and written in a row without these modifications!
@@ -179,9 +182,6 @@ Example
 
 .. note:: PHP needs to be build with FTP support for this backend to work.
 
-.. note:: A non-blocking or correctly configured SELinux setup is needed
-   for this backend to work.
-
 .. note:: The external storage ``FTP/FTPS/SFTP`` needs the ``allow_url_fopen`` PHP
    setting to be set to ``1``. When having connection problems make sure that it is
    not set to ``0`` in your ``php.ini``.
@@ -235,8 +235,6 @@ takes the following options:
 -  **share**: the share on the samba server to mount
 -  **root**: the remote subfolder inside the samba share to mount (optional, defaults
    to ‘/’). To assign the ownCloud logon username automatically to the subfolder, use ``$user`` instead of a particular subfolder name.
-
-.. note:: The SMB backend requires **smbclient** to be installed on the server.
 
 Example
 ^^^^^^^

--- a/admin_manual/configuration_files/external_storage_configuration_gui.rst
+++ b/admin_manual/configuration_files/external_storage_configuration_gui.rst
@@ -44,6 +44,9 @@ ownCloud admins may mount these external storage services and devices:
 ownCloud users can be given permission to mount any of these, except local 
 storage.
 
+.. note:: A non-blocking or correctly configured SELinux setup is needed
+   for these backends to work. Please refer to the :ref:`selinux-config-label`.
+
 Enabling External Storage Support
 ---------------------------------
 
@@ -209,9 +212,6 @@ Connecting to an FTP server requires:
   FTP session with SSL/TLS over ``ftps://`` (Your FTP server must be 
   configured to support ``ftps://``)
 * Enter the ownCloud users or groups who are allowed to access the share.  
-
-.. note:: A non-blocking or correctly configured SELinux setup is needed
-   for this backend to work.
 
 .. note:: The external storage ``FTP/FTPS/SFTP`` needs the ``allow_url_fopen`` PHP
    setting to be set to ``1``. When having connection problems make sure that it is

--- a/admin_manual/installation/selinux_configuration.rst
+++ b/admin_manual/installation/selinux_configuration.rst
@@ -1,3 +1,5 @@
+.. _selinux-config-label:
+
 =====================
 SELinux Configuration
 =====================
@@ -56,3 +58,10 @@ the app store. To allow this access use the following setting::
 
  setsebool -P httpd_can_network_connect on
 
+Allow access to SMTP/sendmail
+-----------------------------
+
+If you want to allow ownCloud to send out e-mail notifications via sendmail you need
+to use the following setting::
+
+ setsebool -P httpd_can_sendmail on


### PR DESCRIPTION
Fixes #1378

Also removed the ``smbclient`` reference for master as there is the new SMB implementation without smbclient since oC 8.1

Additionally a direct reference from the external storages docs to the SELinux config