### PR TITLE
Reference to SELinux docs in user backends

### DIFF
--- a/admin_manual/configuration_user/user_auth_ftp_smb_imap.rst
+++ b/admin_manual/configuration_user/user_auth_ftp_smb_imap.rst
@@ -18,6 +18,9 @@ syntax:
       ),
   ),
 
+.. note:: A non-blocking or correctly configured SELinux setup is needed
+   for these backends to work. Please refer to the :ref:`selinux-config-label`.
+
 Currently the “External user support” (user_external) app, which you need to
 enable first (See :doc:`../installation/apps_management_installation`)
 provides the following user backends:

--- a/admin_manual/configuration_user/user_auth_ldap.rst
+++ b/admin_manual/configuration_user/user_auth_ldap.rst
@@ -27,7 +27,10 @@ The LDAP application supports:
 * Read-only access to your LDAP (no edit or delete of users on your LDAP) 
 
 .. Note:: The LDAP app is not compatible with the ``User backend using remote HTTP servers`` app. 
-   You cannot use both of them at the same time. 
+   You cannot use both of them at the same time.
+
+.. note:: A non-blocking or correctly configured SELinux setup is needed
+   for the LDAP backend to work. Please refer to the :ref:`selinux-config-label`.
 
 Configuration
 -------------


### PR DESCRIPTION
Need moar labels. Backports in #1395, #1396 and #1397 