### PR TITLE
Dev Core Translation emphasize why not to split a sentence

### DIFF
--- a/developer_manual/core/translation.rst
+++ b/developer_manual/core/translation.rst
@@ -17,7 +17,7 @@ You shall never split sentences!
 Reason:
 ~~~~~~~
 
-Translators lose the context and they have no chance to possible re-arrange words.
+Translators lose the context and they have no chance to possibly re-arrange words.
 
 Example:
 ~~~~~~~~
@@ -34,7 +34,7 @@ Translators will translate:
 * ' or "
 * cloud
 
-By translating these individual strings for sure the case will be lost of local filesystem and cloud. The two white spaces with the or will get lost while translating as well.
+By translating these individual strings for sure the case will be lost of local filesystem and cloud. The two white spaces with the or will get lost while translating as well. For languages that have a different grammatical order it prevents the translators from reordering the sentence components.
 
 Html on translation string:
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -44,7 +44,7 @@ Html tags in translation strings is ugly but usually translators can handle this
 What about variable in the strings?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-In case you need to add variables to the translation strings do it like that:
+If you need to add variables to the translation strings do it like this:
 
 .. code-block:: php
 


### PR DESCRIPTION
While fixing a few minor grammar things, I also felt it would be useful to add an extra sentence to explain why translation does not work in little pieces of a sentence. I work in Nepal and speak Nepali as well as English. The Nepali grammar order is subject-object-verb and it does not work to translate "The dog" "bit" "the man" as 3 pieces - the result has to also be reordered as "The dog" "to the man" "bit". "the man" also has to get an object indicator on it, which would be different if it was the subject of the sentence...