### PR TITLE
Add link to CalDAV and CardDAV troubleshooting to user manual

### DIFF
--- a/user_manual/pim/contacts.rst
+++ b/user_manual/pim/contacts.rst
@@ -344,5 +344,7 @@ Additionally, the Contacts app is providing an URL for special functions:
 Troubleshooting
 ---------------
 
-Are you having problems using the app? Have a look at the :doc:`troubleshooting` guide.
+Are you having problems using the app? Have a look at the :doc:`troubleshooting`
+and `Troubleshooting Contacts & Calendar`_ guides.
 
+.. _Troubleshooting Contacts & Calendar: https://doc.owncloud.org/server/8.2/admin_manual/issues/index.html#troubleshooting-contacts-calendar

--- a/user_manual/pim/sync_ios.rst
+++ b/user_manual/pim/sync_ios.rst
@@ -48,6 +48,8 @@ Address book
    -  Change port to 80.
    -  Go back to account information and hit Save.
 
-Now should now find your contacts in the address book of your
-iPhone.
-If it's still not working, have a look at the :doc:`troubleshooting` guide.
+Now should now find your contacts in the address book of your iPhone.
+If it's still not working, have a look at the :doc:`troubleshooting`
+and `Troubleshooting Contacts & Calendar`_ guides.
+
+.. _Troubleshooting Contacts & Calendar: https://doc.owncloud.org/server/8.2/admin_manual/issues/index.html#troubleshooting-contacts-calendar

--- a/user_manual/pim/sync_osx.rst
+++ b/user_manual/pim/sync_osx.rst
@@ -27,9 +27,11 @@ The setup is basically the same as with iOS using the path **ADDRESS/remote.php/
 
 11. You may have to restart addressbook once more. After this, it should work.
 
-If it's still not working, have a look at the :doc:`troubleshooting` guide.
+If it's still not working, have a look at the :doc:`troubleshooting` and
+`Troubleshooting Contacts & Calendar`_ guides.
 
 There is also an easy `HOWTO`_ in the forum.
 
 
 .. _HOWTO: http://forum.owncloud.org/viewtopic.php?f=3&t=132
+.. _Troubleshooting Contacts & Calendar: https://doc.owncloud.org/server/8.2/admin_manual/issues/index.html#troubleshooting-contacts-calendar


### PR DESCRIPTION
Sorry, missed that while doing https://github.com/owncloud/documentation/pull/929

Not quite sure if the reference from the user_manual to the admin_manual works like this?