### PR TITLE
Typo is fixed

### DIFF
--- a/admin_manual/maintenance/upgrade.rst
+++ b/admin_manual/maintenance/upgrade.rst
@@ -155,7 +155,7 @@ If you are upgrading to a major release, for example from 7.0.5 to
 compatibility with your new ownCloud version. Then disable all of them 
 before starting the upgrade.
 
-Next putting your server in maintenance mode. This prevents new logins, 
+Next put your server in maintenance mode. This prevents new logins, 
 locks the sessions of logged-in users, and displays a status screen so users 
 know what is happening. There are two ways to do this, and the preferred method 
 is to use the ``occ`` command, which you must run as your HTTP user. This example


### PR DESCRIPTION
I fixed the typo mentioned in https://github.com/owncloud/documentation/pull/1460. This existed also in stable8.1.