### PR TITLE
File locking transactional minor edit 8.1

### DIFF
--- a/admin_manual/configuration_files/files_locking_transactional.rst
+++ b/admin_manual/configuration_files/files_locking_transactional.rst
@@ -15,7 +15,7 @@ The new file locking mechanism has these capabilities:
   files inside the directories
 * Releases locks after file transactions are interrupted, for 
   example when a sync client loses the connection during an upload
-* Manage locking and releasing locks correctly on shared files during changes 
+* Manages locking and releasing locks correctly on shared files during changes 
   from multiple users
 * Manages locks correctly on external storage mounts
 * Manages encrypted files correctly


### PR DESCRIPTION
Backport of https://github.com/owncloud/documentation/pull/1521
Note: This doc does not exist in 8.0 so no backport needed for that.