### PR TITLE
Insert a note for path to cron.php

### DIFF
--- a/admin_manual/configuration_server/background_jobs_configuration.rst
+++ b/admin_manual/configuration_server/background_jobs_configuration.rst
@@ -54,6 +54,8 @@ You can verify if the cron job has been added and scheduled by executing::
   # crontab -u www-data -l
   */15  *  *  *  * php -f /var/www/owncloud/cron.php
 
+.. note:: You have to replace the path ``/var/www/owncloud/cron.php`` with the path to your current ownCloud installation.
+
 .. note:: On some systems it might be required to call **php-cli** instead of **php**.
 
 .. note:: Please refer to the crontab man page for the exact command syntax.


### PR DESCRIPTION
Hi,
I have inserted a short note that the path to the cron.php hast to be adjusted to the current installation directory. In my opinion this note helps to avoid confusion.