### PR TITLE
Discourage users from copying everything from config.sample.php

### DIFF
--- a/admin_manual/configuration_server/config_sample_php_parameters.rst
+++ b/admin_manual/configuration_server/config_sample_php_parameters.rst
@@ -3,9 +3,14 @@ Config.php Parameters
 =====================
 ownCloud uses the ``config/config.php`` file to control server operations.
 ``config/config.sample.php`` lists all the configurable parameters within
-ownCloud. This document provides a more detailed reference. Many options are
-configurable on your Admin page, so it is usually not necessary to edit
-``config/config.php``.
+ownCloud along with example or default values. This document provides a more
+detailed reference. Many options are configurable on your Admin page, so it
+is usually not necessary to edit ``config/config.php``.
+
+.. note:: The installer creates a config containing the essential parameters.
+   Only manually add config parameters to ``config/config.php`` if you need to
+   use a special value for a parameter. Do not copy everything from
+   ``config/config.sample.php``.
 
 ownCloud supports loading configuration parameters from multiple files.
 You can add arbitrary files ending with :file:`.config.php` in the :file:`config/`


### PR DESCRIPTION
Here is an alternative suggestion for wording related to https://github.com/owncloud/documentation/pull/1681