### PR TITLE
Fix rst syntax in config_sample_php_parameters.

### DIFF
--- a/admin_manual/configuration_server/config_sample_php_parameters.rst
+++ b/admin_manual/configuration_server/config_sample_php_parameters.rst
@@ -10,8 +10,8 @@ is usually not necessary to edit ``config/config.php``.
 
 .. note:: The installer creates a configuration containing the essential parameters.
    Only manually add configuration parameters to ``config/config.php`` if you need to
-   use a special value for a parameter. **Do not copy everything from
-   ``config/config.sample.php``. Only enter the parameters you wish to modify!**
+   use a special value for a parameter. **Do not copy everything from**
+   ``config/config.sample.php`` **. Only enter the parameters you wish to modify!**
 
 ownCloud supports loading configuration parameters from multiple files.
 You can add arbitrary files ending with :file:`.config.php` in the :file:`config/`


### PR DESCRIPTION
Seems bold and the `` syntax won't work together:

https://doc.owncloud.org/server/8.1/admin_manual/configuration_server/config_sample_php_parameters.html#config-php-parameters