### PR TITLE
postScanFile and postScanFolder are now available in OC\Files\Utils\Scanner

### DIFF
--- a/developer_manual/app/hooks.rst
+++ b/developer_manual/app/hooks.rst
@@ -156,7 +156,9 @@ Filesystem hooks available in scope **\\OC\\Files**:
 
 Filesystem Scanner
 ------------------
-Filesystem scanner hooks available in scope **\\OC\\Utils\\Scanner**:
+Filesystem scanner hooks available in scope **\\OC\\Files\\Utils\\Scanner**:
 
 * **scanFile** (string $absolutePath)
 * **scanFolder** (string $absolutePath)
+* **postScanFile** (string $absolutePath)
+* **postScanFolder** (string $absolutePath)


### PR DESCRIPTION
Reflect the changes introduced by https://github.com/owncloud/core/pull/19460

@MorrisJobke @icewind1991 