### PR TITLE
"Other" category is gone at the appstore

### DIFF
--- a/developer_manual/app/info.rst
+++ b/developer_manual/app/info.rst
@@ -29,7 +29,7 @@ The :file:`appinfo/info.xml` contains metadata about the app:
           <admin>http://doc.owncloud.org</admin>
       </documentation>
 
-      <category>other</category>
+      <category>tool</category>
 
       <website>http://www.owncloud.org</website>
 
@@ -137,7 +137,6 @@ category
 --------
 Category on the app store. Can be one of the following:
 
-* other
 * multimedia
 * pim
 * productivity

--- a/developer_manual/app/tutorial.rst
+++ b/developer_manual/app/tutorial.rst
@@ -266,7 +266,7 @@ To create the tables in the database, the :doc:`version tag <info>` in **ownnote
         <author>Your Name</author>
         <version>0.0.2</version>
         <namespace>OwnNotes</namespace>
-        <category>other</category>
+        <category>tool</category>
         <dependencies>
             <owncloud min-version="8" />
         </dependencies>


### PR DESCRIPTION
Ref: https://github.com/owncloud/appstore-issues/issues/26