### PR TITLE
Updates to user_auth_ldap.rst

### DIFF
--- a/admin_manual/configuration_user/user_auth_ldap.rst
+++ b/admin_manual/configuration_user/user_auth_ldap.rst
@@ -559,7 +559,7 @@ ownCloud LDAP Internals
 Some parts of how the LDAP backend works are described here.
 
 User and Group Mapping
-----------------------
+^^^^^^^^^^^^^^^^^^^^^^
 
 In ownCloud the user or group name is used to have all relevant information in
 the database assigned. To work reliably a permanent internal user name and
@@ -579,41 +579,16 @@ it into production. The mapping tables are filled early, but as long as you are
 testing, you can empty the tables any time. Do not do this in production.
 
 Caching
--------
+^^^^^^
 
 The LDAP cache has changed in ownCloud 8.1. There is no more file cache, but 
 only a memory cache, and you must install and configure the memory cache (see 
-:doc:`../configuration_server/caching_configuration`). The 
-simplest memory cache to use is APCu. This is supplied by the ``php5-apcu`` 
-package on Debian/Ubuntu/Mint, and by ``php-pecl-apcu`` on Red 
-Hat/CentOS/Fedora.
-
-After installing APCu you must modify ``config.php`` to select APCu as the 
-ownCloud cache::
-
- 'memcache.local' => '\OC\Memcache\APCu',
+:doc:`../configuration_server/caching_configuration`).
  
 The ownCloud  **Cache** helps to speed up user interactions and sharing. It is 
 populated on demand, and remains populated until the **Cache Time-To-Live** for 
 each unique request expires. User logins are not cached, so if you need to
 improve login times set up a slave LDAP server to share the load.
-
-The Redis key-value cache and store is an excellent fast and robust cache, and 
-if you are using :doc:`Transaction File Locking 
-<../configuration_files/files_locking_transactional>`) then you must use Redis. 
-A Redis configuration looks like this::
-
- 'filelocking.enabled' => 'true',
- 'memcache.local' => '\OC\Memcache\Redis',
- 'redis' => array(
-       'host' => 'localhost',
-       'port' => 6379,
-       'timeout' => 0.0,
-       ),
-
-Redis is supplied by the ``redis-server`` and ``php5-redis`` packages on 
-Debian/Ubuntu/Mint, and on Red Hat/CentOS/Fedora by ``redis`` and 
-``php-pecl-redis`` from the EPEL repository. 
 
 You can adjust the **Cache Time-To-Live** value to balance performance and 
 freshness of LDAP data. All LDAP requests will be cached for 10 minutes by 
@@ -641,10 +616,22 @@ defunct, for example due to a server migration or unreachable server. In this
 case the other servers will also receive the request.
 
 Handling with Backup Server
----------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 When ownCloud is not able to contact the main LDAP server, ownCloud assumes it 
 is offline and will not try to connect again for the time specified in **Cache 
 Time-To-Live**. If you have a backup server configured ownCloud will connect to 
 it instead. When you have scheduled downtime, check **Disable Main Server**  to 
 avoid unnecessary connection attempts.
+
+LDAP Quota Sync/Update
+^^^^^^^^^^^^^^^^^^^^^^
+
+After the quota provided by LDAP was updated please note that the ownCloud internal
+quota is not updated before:
+
+* 24 hours since the last refresh
+* the user is either referred (like an update of a shared folder) or logs in himself
+
+To sum-up a user needs to login or have files/folders shared with him which gets
+an update after the quota sync.


### PR DESCRIPTION
Fixes #1250 . Tried to write something together based on the spare info provided in #1250.

Also removed the caching instructions there as the new caching page has more detailed infos which is already linked there. Additional fixed the headlines from the "ownCloud LDAP Internals" part.