### PR TITLE
update occ with gobs of new commands

### DIFF
--- a/admin_manual/configuration_files/encryption_configuration.rst
+++ b/admin_manual/configuration_files/encryption_configuration.rst
@@ -3,7 +3,7 @@ Encryption Configuration
 ========================
 
 If you are upgrading from ownCloud 8.0, and have encryption enabled, please see 
-:ref:`upgrading` (below) for the correct steps to upgrade your encryption. 
+:ref:`upgrading_encryption_label` (below) for the correct steps to upgrade your encryption. 
 
 In ownCloud 8.1 and up the server-side encryption has a number of changes and 
 improvements, including:
@@ -81,12 +81,9 @@ storage.
 Before Enabling Encryption
 --------------------------
 
-Plan very carefully before enabling encryption because **it is not 
-reversible**, and if you lose your encryption keys your files are not 
-recoverable. Always have backups of your encryption keys stored in a safe 
-location, and consider enabling all recovery options.
+Plan very carefully before enabling encryption because if you lose your encryption keys your files are not recoverable. Always have backups of your encryption keys stored in a safe location, and consider enabling all recovery options.
 
-.. _enable_encryption:
+.. _enable_encryption_label:
 
 Enabling Encryption
 -------------------
@@ -193,8 +190,7 @@ Select a different default Encryption module::
  
 The [module ID] is taken from the ``encryption:list-modules`` command. 
  
-See :doc:`../configuration_server/occ_command` for detailed instructions on 
-using ``occ``.
+See :ref:`encryption_label`  for detailed instructions on using ``occ``.
 
 Files Not Encrypted
 -------------------
@@ -222,7 +218,7 @@ Key then you can change a user's password in the ownCloud Users panel to match
 their back-end password, and then, of course, notify the user and give them 
 their new password.
 
-.. _upgrading:
+.. _upgrading_encryption_label:
 
 Upgrading From ownCloud 8.0
 ---------------------------
@@ -236,7 +232,7 @@ Before you start your upgrade, put your ownCloud server into
 You must do this to prevent users and sync clients from accessing files before 
 you have completed your encryption migration.
 
-After your upgrade is complete, follow the steps in :ref:`enable_encryption` to 
+After your upgrade is complete, follow the steps in :ref:`enable_encryption_label` to 
 enable the new encryption system. Then click the **Start Migration** button on 
 your Admin page to migrate your encryption keys, or use the ``occ`` command. We 
 strongly recommend using the ``occ`` command; the **Start Migration** button is 
@@ -327,28 +323,5 @@ File keys for files owned by the user:
 Share keys for files owned by the user (one key for the owner and one key for each user with access to the file):
  :file:`data/<user>/files_encryption/keys/<file_path>/<filename>/OC_DEFAULT_MODULE/<user>.shareKey`
 
-
-
-
-.. This section commented out because there is no windows support
-.. in oC8; un-comment this if windows support is restored
-.. "Missing requirements" Message on Windows Servers
-.. --------------------------------------------------
-
-.. If you get a "Missing requirements" error message when you enable encryption 
-.. on a Windows server, enter the absolute location of your openSSL 
-.. configuration file in ``config.php``::
-
-..   'openssl' => array(
-..      'config' => 'C:\path\to\openssl.cnf',
-..  ),
-  
-.. For example, in a typical installation on a 64-bit Windows 7 system it looks 
-.. like this::
-
-..  'openssl' => array(
-..      'config' => 'C:\OpenSSL-Win64\openssl.cnf',
-..  ),
-
-.. There are many ways to configure OpenSSL, so be sure to verify your correct 
-.. file location.
+.. references --  https://github.com/owncloud/QA/issues/16
+.. 

--- a/admin_manual/configuration_server/occ_command.rst
+++ b/admin_manual/configuration_server/occ_command.rst
@@ -342,7 +342,7 @@ Users must have enabled recovery keys on their Personal pages. You must first pu
 
 Use ``encryption:disable`` to disable your encryption module. You must first put your ownCloud server into single-user mode to prevent any user activity.
 
-``encryption:enable-master-key`` creates a new master key, which is used for all user data instead of individual user keys. This is especially useful to enable single-sign on Use this only on fresh installations with no existing data, or on systems where encryption has not already been enabled. It is not possible to disable it.
+``encryption:enable-master-key`` creates a new master key, which is used for all user data instead of individual user keys. This is especially useful to enable single-sign on. Use this only on fresh installations with no existing data, or on systems where encryption has not already been enabled. It is not possible to disable it.
 
 ``encryption:migrate`` migatres encryption keys after a major ownCloud version upgrade. You may optionally specify individual users in a space-delimited list.
 
@@ -745,7 +745,7 @@ Supported databases are::
 Command Line Upgrade
 --------------------
 
-These commands are available only after you have download upgraded packages or archives, and before you complete the upgrade.
+These commands are available only after you have downloaded upgraded packages or archives, and before you complete the upgrade.
 
 List all options, like this example on CentOS Linux::
 

--- a/admin_manual/configuration_server/occ_command.rst
+++ b/admin_manual/configuration_server/occ_command.rst
@@ -510,8 +510,12 @@ Use the ``--enable`` option to turn on logging. Use ``--file`` to set a differen
 Maintenance Commands
 --------------------
 
-These maintenance commands put your ownCloud server into
-maintenance and single-user mode, and run repair steps during updates.
+The available maintenance commands are:
+
+* maintenance:mimetype:update-db
+* maintenance:mode
+* maintenance:repair 
+* maintenance:singleuser
 
 You must put your ownCloud server into maintenance mode whenever you perform an 
 update or upgrade. This locks the sessions of all logged-in users, including 
@@ -530,7 +534,7 @@ troubleshooting on a running server::
  $ sudo -u www-data php occ maintenance:singleuser --on
    Single user mode enabled
    
-And turn it off when you're finished::
+Turn it off when you're finished::
 
  $ sudo -u www-data php occ maintenance:singleuser --off
    Single user mode disabled
@@ -551,8 +555,10 @@ to::
      - 0 tags for delete files have been removed.
      - 0 tag entries for deleted tags have been removed.
      - 0 tags with no entries have been removed.
- - Re-enable file app    
+ - Re-enable file app
  
+``maintenance:mimetype:update-db`` updates the ownCloud database and file cache with changed mimetypes found in ``config/mimetypemapping.json``. Run this command after modifying ``config/mimetypemapping.json``. If you change a mimetype, run ``maintenance:mimetype:update-db --repair-filecache`` to apply the change to existing files.
+
 .. _user_commands_label: 
  
 User Commands

--- a/admin_manual/configuration_server/occ_command.rst
+++ b/admin_manual/configuration_server/occ_command.rst
@@ -421,7 +421,7 @@ Names of Languages
 LDAP Commands
 -------------
 
-These LDAP commands appear only when you have enabled the LDAP backend. Then you can run the following LDAP commands with ``occ``.
+These LDAP commands appear only when you have enabled the LDAP backend on your Apps page. Then you can run the following LDAP commands with ``occ``.
 
 Search for an LDAP user, using this syntax::
 

--- a/admin_manual/configuration_server/occ_command.rst
+++ b/admin_manual/configuration_server/occ_command.rst
@@ -421,7 +421,7 @@ Names of Languages
 LDAP Commands
 -------------
 
-You can run the following LDAP commands with ``occ``.
+These LDAP commands appear only when you have enabled the LDAP backend. Then you can run the following LDAP commands with ``occ``.
 
 Search for an LDAP user, using this syntax::
 
@@ -652,6 +652,8 @@ authentication servers such as LDAP::
 Command Line Installation
 -------------------------
 
+These commands are available only after you have downloaded and unpacked the ownCloud archive, and before you complete the installation.
+
 You can install ownCloud entirely from the command line. After downloading the 
 tarball and copying ownCloud into the appropriate directories, or 
 after installing ownCloud packages (See 
@@ -742,6 +744,8 @@ Supported databases are::
    
 Command Line Upgrade
 --------------------
+
+These commands are available only after you have download upgraded packages or archives, and before you complete the upgrade.
 
 List all options, like this example on CentOS Linux::
 

--- a/admin_manual/installation/command_line_installation.rst
+++ b/admin_manual/installation/command_line_installation.rst
@@ -17,7 +17,7 @@ and unpack the tarball in the appropriate directories. (See
 3. Use the ``occ`` command to complete your installation. This takes the place 
 of running the graphical Installation Wizard.
 
-You must run ``occ`` as your HTTP user; see :ref:`http_user`. This example 
+You must run ``occ`` as your HTTP user; see :ref:`http_user_label`. This example 
 shows how to complete your ownCloud installation with ``occ`` on Ubuntu Linux::
 
  $ cd /var/www/owncloud/
@@ -38,4 +38,4 @@ Supported databases are::
  - pgsql (PostgreSQL)
  - oci (Oracle)
  
-See :ref:`cli_installation` for more information. 
+See :ref:`command_line_installation_label` for more information. 


### PR DESCRIPTION
For 8.2 only.
Have the LDAP commands been removed? I do not see them in 'php occ list'
Please review @schiesbn (encryption)
@MorrisJobke @blizzz (where have all the LDAP gone?)