### PR TITLE
Add redis example to connect to an unix socket.

### DIFF
--- a/admin_manual/configuration_files/files_locking_transactional.rst
+++ b/admin_manual/configuration_files/files_locking_transactional.rst
@@ -34,7 +34,19 @@ file like this example::
        'port' => 6379,
        'timeout' => 0.0,
         ),
-        
+
+If you want to connect to Redis configured to listen on an unix socket (which is
+recommended if Redis is running on the same system as ownCloud) use this example
+``config.php`` configuration::
+
+  'filelocking.enabled' => 'true',
+  'memcache.locking' => '\OC\Memcache\Redis',
+  'redis' => array(
+       'host' => '/var/run/redis/redis.sock',
+       'port' => 0,
+       'timeout' => 0.0,
+        ),
+   
 .. note:: Large installations especially benefit from setting 
    ``memcache.locking``. File locking is enabled by default, which uses the 
    database locking backend. This places a significant load on your database. 

--- a/admin_manual/configuration_server/caching_configuration.rst
+++ b/admin_manual/configuration_server/caching_configuration.rst
@@ -180,6 +180,17 @@ Redis for the local server cache::
        'timeout' => 0.0,
         ),
 
+If you want to connect to Redis configured to listen on an unix socket (which is
+recommended if Redis is running on the same system as ownCloud) use this example
+``config.php`` configuration::
+
+  'memcache.local' => '\OC\Memcache\Redis',
+  'redis' => array(
+       'host' => '/var/run/redis/redis.sock',
+       'port' => 0,
+       'timeout' => 0.0,
+        ),
+
 Redis is very configurable; consult `the Redis documentation 
 <http://redis.io/documentation>`_ to learn more.
 


### PR DESCRIPTION
Just had a chat with an user on IRC yesterday. Its not that clear that, if you want to connect to an unix socket that the port still needs to be there in the redis array. So just adding two (here working) examples for the caching and file locking configs.