### PR TITLE
Max. upload of 4GB also valid for IE11

### DIFF
--- a/admin_manual/configuration_files/big_file_upload_configuration.rst
+++ b/admin_manual/configuration_files/big_file_upload_configuration.rst
@@ -10,7 +10,7 @@ hard limits that cannot be exceeded:
 * < 2GB on Windows (32Bit and 64Bit)
 * < 2GB with Server Version 4.5 or older
 * < 2GB with IE6 - IE8
-* < 4GB with IE9 - IE10
+* < 4GB with IE9 - IE11
 
 64-bit filesystems have much higher limits; consult the documentation for your 
 filesystem.


### PR DESCRIPTION
Ref: http://blogs.msdn.com/b/ieinternals/archive/2011/03/10/wininet-internet-explorer-file-download-and-upload-maximum-size-limits.aspx

as also seen in: https://forum.owncloud.org/viewtopic.php?f=31&t=30874#p98692