### PR TITLE
Documentation for .well-known urls when running in subdir

### DIFF
--- a/admin_manual/installation/linux_installation.rst
+++ b/admin_manual/installation/linux_installation.rst
@@ -70,3 +70,7 @@ Mageia software repository.
 ``/etc/apache2/conf.d/owncloud.conf`` which contains an ``Alias`` to the 
 owncloud installation directory as well as some more needed configuration 
 options.
+
+**Running ownCloud in a subdir**: If you're running ownCloud in a subdir and
+want to use CalDAV or CardDAV clients make sure you have configured the correct 
+:ref:`service-discovery-label` URLs.

--- a/admin_manual/installation/source_installation.rst
+++ b/admin_manual/installation/source_installation.rst
@@ -208,19 +208,22 @@ Additional Apache Configurations
   the  server configuration, as well as in the CommonName field of the 
   certificate. If you want your ownCloud to be reachable via the internet, then 
   set both of these to the domain you want to reach your ownCloud server.
-  
+
 * Now restart Apache::
-  
+
      service apache2 restart
-     
-.. note:: You can use ownCloud over plain HTTP, but we strongly encourage you to
-          use SSL/TLS to encrypt all of your server traffic, and to protect 
-          user's logins and data in transit.
+
+* If you're running ownCloud in a subdir and want to use CalDAV or CardDAV clients
+  make sure you have configured the correct :ref:`service-discovery-label` URLs.
 
 .. _enabling-ssl-label:
 
 Enabling SSL
 ------------
+
+.. note:: You can use ownCloud over plain HTTP, but we strongly encourage you to
+          use SSL/TLS to encrypt all of your server traffic, and to protect 
+          user's logins and data in transit.
 
 Apache installed under Ubuntu comes already set-up with a simple
 self-signed certificate. All you have to do is to enable the ssl module and

--- a/admin_manual/issues/index.rst
+++ b/admin_manual/issues/index.rst
@@ -239,6 +239,8 @@ which contains various additional information about WebDAV problems.
 Troubleshooting Contacts & Calendar
 -----------------------------------
 
+.. _service-discovery-label:
+
 Service discovery
 ^^^^^^^^^^^^^^^^^
 
@@ -247,11 +249,6 @@ when explicitly configured to use it.
 
 There are several techniques to remedy this, which are described extensively at 
 the `Sabre DAV website <http://sabre.io/dav/service-discovery/>`_.
-
-Apple iOS
-^^^^^^^^^
-
-Below is what has been proven to work with iOS including iOS 7.
 
 If your ownCloud instance is installed in a subfolder under the web server's 
 document root and the client has difficulties finding the Cal- or CardDAV 


### PR DESCRIPTION
Fixes #1800 , ref: https://github.com/owncloud/core/issues/20012

Removed the headlines as this is also affecting not only iOS and also moved the SSL notes box to the correct place.