### PR TITLE
Disable 3rdparty / non-shipped apps when having issues.

### DIFF
--- a/admin_manual/issues/index.rst
+++ b/admin_manual/issues/index.rst
@@ -47,6 +47,13 @@ If you can't find a solution, please use our `bugtracker`_.
 General Troubleshooting
 -----------------------
 
+Disable 3rdparty / non-shipped apps
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+It might be possible that 3rdparty / non-shipped apps are causing various different
+issues. Please refer to the :ref:`apps_commands_label` on how to disable an app
+from command line.
+
 ownCloud Logfiles
 ^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
It should be obvious that this is the first thing to check but could be useful anyway to document it.

Music for example had broken the anonymous uploads (https://github.com/owncloud/music/issues/387) where Storagecharts2 hat caused a redirect loop (https://github.com/hypery2k/owncloud/issues/351).