### PR TITLE
Add redis password support to caching and files locking docs.

### DIFF
--- a/admin_manual/configuration_files/files_locking_transactional.rst
+++ b/admin_manual/configuration_files/files_locking_transactional.rst
@@ -33,7 +33,11 @@ file like this example::
        'host' => 'localhost',
        'port' => 6379,
        'timeout' => 0.0,
+       'password' => '', // Optional, if not defined no password will be used.
         ),
+
+.. note:: For enhanced security it is recommended to configure Redis to require
+   a password. See http://redis.io/topics/security for more information.
 
 If you want to connect to Redis configured to listen on an unix socket (which is
 recommended if Redis is running on the same system as ownCloud) use this example

--- a/admin_manual/configuration_server/caching_configuration.rst
+++ b/admin_manual/configuration_server/caching_configuration.rst
@@ -178,7 +178,11 @@ Redis for the local server cache::
        'host' => 'localhost',
        'port' => 6379,
        'timeout' => 0.0,
+       'password' => '', // Optional, if not defined no password will be used.
         ),
+
+.. note:: For enhanced security it is recommended to configure Redis to require
+   a password. See http://redis.io/topics/security for more information.
 
 If you want to connect to Redis configured to listen on an unix socket (which is
 recommended if Redis is running on the same system as ownCloud) use this example


### PR DESCRIPTION
Refs:

https://github.com/owncloud/core/pull/20193 and https://github.com/owncloud/documentation/commit/05d716fc60965bd0a5f3f200de4dfc4f48f6966a