### PR TITLE
Revert "Backport to stable8.1 | Server Status removal"

### DIFF
--- a/admin_manual/configuration_files/files_locking_transactional.rst
+++ b/admin_manual/configuration_files/files_locking_transactional.rst
@@ -47,6 +47,13 @@ recommended if Redis is running on the same system as ownCloud) use this example
        'timeout' => 0.0,
         ),
 
+The **Server status** section on your ownCloud Admin page indicates whether 
+transactional file locking is enabled or disabled.
+
+.. figure:: ../images/transactional-locking-1.png
+
+.. figure:: ../images/transactional-locking-2.png
+
 See ``config.sample.php`` to see configuration examples for Redis, and for all 
 supported memcaches.
 


### PR DESCRIPTION
Revert owncloud/documentation#1854

![screenshot 2015-11-03 at 11 14 14](https://cloud.githubusercontent.com/assets/2359059/10905678/131d66ac-821c-11e5-8ec3-cb241210aea7.png)

Related to https://github.com/owncloud/core/pull/18778