### PR TITLE
[stable8.1] Add banner that this is not the newest version

### DIFF
--- a/_shared_assets/themes/owncloud_org/layout.html
+++ b/_shared_assets/themes/owncloud_org/layout.html
@@ -53,6 +53,9 @@
 
 {# Sidebar: Rework into our Bootstrap nav section. #}
 {% macro navBar() %}
+<div class="alert alert-warning" style="margin-bottom: 0px;">
+    This document is for an older version of ownCloud. Click <a href="https://doc.owncloud.org/">here</a> to get a list of more up-to-date documentation resources.
+</div>
 <header class="banner navbar navbar-default navbar-static-top" role="banner">
   <div class="container">
     <div class="navbar-header">


### PR DESCRIPTION
Fixes https://github.com/owncloud/documentation/issues/1810

The following appears now on every page:

![2015-11-05_16-38-48](https://cloud.githubusercontent.com/assets/878997/10972969/d9a08b22-83db-11e5-9926-0d07610a7baa.png)

Obviously somebody needs to do this manually all the time for each branch that gets outdated :wink: 

@jospoortvliet @carlaschroder @RealRancor Thoughts?
