### PR TITLE
misinterpretation of php's max_file_uploads

### DIFF
--- a/admin_manual/configuration_server/performance_tuning/webserver_tips.rst
+++ b/admin_manual/configuration_server/performance_tuning/webserver_tips.rst
@@ -12,14 +12,6 @@ on/off``. If it is on, then add this line to ``php.ini`` to turn it off::
 
  safe_mode = Off
 
-Raise max_file_uploads of PHP
------------------------------
-
-The PHP setting ``max_file_uploads`` within the ``php.ini`` defaults to ``20``
-on most environments which allows that number of simultaneous uploads.
-Currently the ownCloud sync client is doing ``3`` parallel uploads which means
-that at least ``6`` clients can upload files simultaneously. Depending on your
-server usage it is recommended to raise this number to a higher value.
 
 Enable the SPDY / http_v2 protocol
 ----------------------------------


### PR DESCRIPTION
The value of max_file_uploads limits fileuploads to a maximum of ``max_file_uploads`` within one connection. So multiple users can each upload ``max_file_uploads`` at the same time. And one user can upload 20 files each in multiple connections at the same time. The value does not have to be higher than the maximum number of simutanously uploaded files per connection. If the desktop clients uploads a maximum of 3 files at once, the value could stay at 3. I'm not sure how the webapplication handles the upload of multiple files but the default of 20 seems quite reasonable.