### PR TITLE
MySQL requires the pdo_mysql extension, not mysql.

### DIFF
--- a/admin_manual/configuration_database/linux_database_configuration.rst
+++ b/admin_manual/configuration_database/linux_database_configuration.rst
@@ -57,7 +57,7 @@ Configuring a MySQL or MariaDB Database
 
 If you decide to use a MySQL or MariaDB database, ensure the following:
 
-* That you have installed and enabled the MySQL extension in PHP
+* That you have installed and enabled the pdo_mysql extension in PHP
 
 * That the **mysql.default_socket** points to the correct socket (if the database runs on the same server as ownCloud).
 
@@ -69,7 +69,6 @@ The PHP configuration in :file:`/etc/php5/conf.d/mysql.ini` could look like this
 
   # configuration for PHP MySQL module
   extension=pdo_mysql.so
-  extension=mysql.so
 
   [mysql]
   mysql.allow_local_infile=On

--- a/admin_manual/configuration_server/performance_tuning/database_best_practice.rst
+++ b/admin_manual/configuration_server/performance_tuning/database_best_practice.rst
@@ -54,7 +54,7 @@ See also `this forum thread
 Other performance improvements
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Mysql: compare https://tools.percona.com/wizard to your current settings
+MySQL: compare https://tools.percona.com/wizard to your current settings
 MariaDB: https://mariadb.com/kb/en/optimization-and-tuning/
 
 Postgresql

--- a/admin_manual/installation/appliance_installation.rst
+++ b/admin_manual/installation/appliance_installation.rst
@@ -48,7 +48,7 @@ Follow these steps to get the appliance working:
    When using the ownCloud Proxy app, this Web page may be publicly visible.
 
 .. note:: Inside the VM, ownCloud runs with a default disk size of 40 GB and its 
-   own MySql database. The ownCloud admin user is also a valid account on the 
+   own MySQL database. The ownCloud admin user is also a valid account on the 
    Ubuntu system that runs inside the VM. You can administer the VM via SSH.
 
 **For VMware**

--- a/admin_manual/installation/source_installation.rst
+++ b/admin_manual/installation/source_installation.rst
@@ -61,7 +61,7 @@ Required:
 Database connectors (pick the one for your database:)
 
 * PHP module sqlite (>= 3, usually not recommended for performance reasons)
-* PHP module mysql (MySQL/MariaDB)
+* PHP module pdo_mysql (MySQL/MariaDB)
 * PHP module pgsql (requires PostgreSQL >= 9.0)
 
 *Recommended* packages:


### PR DESCRIPTION
Since ownCloud 8.2, the mysql extension is no longer used. The pdo_mysql extension must be used instead.
Also fix a few typos.

Fixes #1933 