### PR TITLE
nginx config: Don't throw 200/found on non-existent files

### DIFF
--- a/admin_manual/installation/nginx_configuration.rst
+++ b/admin_manual/installation/nginx_configuration.rst
@@ -93,7 +93,7 @@ Nginx Configuration
 
       rewrite ^(/core/doc/[^\/]+/)$ $1/index.html;
 
-      try_files $uri $uri/ /index.php;
+      try_files $uri $uri/ = 404;
     }
 
     location ~ \.php(?:$|/) {


### PR DESCRIPTION
The current nginx config is causing a 200 / Found for every request done like:

https://example.com/abc
https://example.com/non-existing

where a call on:

https://demo.owncloud.org/abc

for example is causing the wanted 404 / File Not Found. This can lead to false positives on security scanners etc.

It seems this has been there for ages (at least with stable5: https://github.com/owncloud/documentation/blob/stable5/admin_manual/installation/installation_others.rst).

cc @josh4trunks