### PR TITLE
Correct valid app category strings for category in XML fixes #2018

### DIFF
--- a/developer_manual/app/info.rst
+++ b/developer_manual/app/info.rst
@@ -139,8 +139,8 @@ Category on the app store. Can be one of the following:
 
 * multimedia
 * productivity
-* games
-* tools
+* game
+* tool
 
 ocsid
 -----


### PR DESCRIPTION
Although the ownCloud App store front-end webGUI has categories "Games" and "Tools" on the left side-bar for users to choose from, the string that goes in the app XML category tag is "game" or "tool".