### PR TITLE
Update the description for proper updating the instance

### DIFF
--- a/admin_manual/installation/installation_wizard.rst
+++ b/admin_manual/installation/installation_wizard.rst
@@ -112,10 +112,10 @@ Setting Strong Directory Permissions
 
 For hardened security we recommend setting the permissions on your ownCloud 
 directories as strictly as possible, and for proper server operations. This 
-should be done immediately after the initial installation. Your HTTP user must 
-own the ``config/``, ``data/`` and ``apps/`` directories so that you can 
-configure ownCloud, create, modify and delete your data files, and install apps 
-via the ownCloud Web interface. 
+should be done immediately after the initial installation and before running the 
+setup. Your HTTP user must own the ``config/``, ``data/`` and ``apps/`` directories 
+so that you can configure ownCloud, create, modify and delete your data files, 
+and install apps via the ownCloud Web interface. 
 
 You can find your HTTP user in your HTTP server configuration files. Or you can 
 use :ref:`label-phpinfo` (Look for the **User/Group** line).
@@ -141,20 +141,35 @@ replace the ``htuser`` and ``htgroup`` variables with your HTTP user and group::
  htgroup='www-data'
  rootuser='root' # On QNAP this is admin
 
+ printf "Creating possible missing Directories\n"
+ mkdir -p $ocpath/data
+ mkdir -p $ocpath/assets
+
+ printf "chmod Files and Directories\n"
  find ${ocpath}/ -type f -print0 | xargs -0 chmod 0640
  find ${ocpath}/ -type d -print0 | xargs -0 chmod 0750
 
+ printf "chown Directories\n"
  chown -R ${rootuser}:${htgroup} ${ocpath}/
  chown -R ${htuser}:${htgroup} ${ocpath}/apps/
  chown -R ${htuser}:${htgroup} ${ocpath}/config/
  chown -R ${htuser}:${htgroup} ${ocpath}/data/
  chown -R ${htuser}:${htgroup} ${ocpath}/themes/
+ chown -R ${htuser}:${htgroup} ${ocpath}/assets/
 
- chown ${rootuser}:${htgroup} ${ocpath}/.htaccess
- chown ${rootuser}:${htgroup} ${ocpath}/data/.htaccess
+ chmod +x ${ocpath}/occ
 
- chmod 0644 ${ocpath}/.htaccess
- chmod 0644 ${ocpath}/data/.htaccess
+ printf "chmod/chown .htaccess\n"
+ if [ -f ${ocpath}/.htaccess ]
+  then
+   chmod 0644 ${ocpath}/.htaccess
+   chown ${rootuser}:${htgroup} ${ocpath}/.htaccess
+ fi
+ if [ -f ${ocpath}/data/.htaccess ]
+  then
+   chmod 0644 ${ocpath}/data/.htaccess
+   chown ${rootuser}:${htgroup} ${ocpath}/data/.htaccess
+ fi
  
 If you have customized your ownCloud installation and your filepaths are 
 different than the standard installation, then modify this script accordingly. 
@@ -170,8 +185,14 @@ and files:
 * The :file:`apps/` directory should be owned by ``[HTTP user]:[HTTP group]``
 * The :file:`config/` directory should be owned by ``[HTTP user]:[HTTP group]``
 * The :file:`themes/` directory should be owned by ``[HTTP user]:[HTTP group]``
+* The :file:`assets/` directory should be owned by ``[HTTP user]:[HTTP group]``
 * The :file:`data/` directory should be owned by ``[HTTP user]:[HTTP group]``
 * The :file:`[ocpath]/.htaccess` file should be owned by ``root:[HTTP group]``
 * The :file:`data/.htaccess` file should be owned by ``root:[HTTP group]``
 * Both :file:`.htaccess` files are read-write file owner, read-only group and 
   world
+
+If you want to update/upgrade your installation via the GUI or the occ-command,
+check :ref:`setting_permissions_for_updating:` in the 
+"Upgrading ownCloud with the Updater App" document.
+ 

--- a/admin_manual/maintenance/update.rst
+++ b/admin_manual/maintenance/update.rst
@@ -51,7 +51,7 @@ steps:
     always have your own current backups (See :doc:`backup` for details.)
    
 3.  Verify that the HTTP user on your system can write to your whole ownCloud 
-    directory; see the :ref:`setting_strong_permissions` section below.
+    directory; see the :ref:`setting_permissions_for_updating` section below.
    
 4.  Navigate to your Admin page and click the `Update Center` button under 
     Updater:
@@ -127,10 +127,10 @@ your server, most likely via your Linux package manager during a routine system
 update. So you only need to click the Start Update button, or run the ``occ`` 
 command to complete the update.
 
-.. _setting_strong_permissions:
+.. _setting_permissions_for_updating:
 
-Setting Strong Permissions
---------------------------
+Setting Permissions for Updating
+--------------------------------
    
 For hardened security we  highly recommend setting the permissions on your 
 ownCloud directory as strictly as possible. These commands should be executed 
@@ -145,20 +145,35 @@ user is::
 
     chown -R <http-user>:<http-user> /path/to/owncloud/
 
-* This example is for Ubuntu 14.04 LTS server::
-   
-    chown -R www-data:www-data /var/www/owncloud
+You can find your HTTP user in your HTTP server configuration files. Or you can 
+use :ref:`label-phpinfo` (Look for the **User/Group** line).
 
-* Arch Linux::
+* The HTTP user and group in Debian/Ubuntu is ``www-data``.
+* The HTTP user and group in Fedora/CentOS is ``apache``.
+* The HTTP user and group in Arch Linux is ``http``.
+* The HTTP user in openSUSE is ``wwwrun``, and the HTTP group is ``www``.
 
-    chown -R http:http /path/to/owncloud/
+Preparing the instance for upgrading
+------------------------------------
 
-* Fedora::
+Replace the ``ocpath`` variable with the path to your ownCloud directory, and 
+replace the ``htuser`` and ``htgroup`` variables with your HTTP user and group.
 
-    chown -R apache:apache /path/to/owncloud/
-	
-* openSUSE::
-
-    chown -R wwwrun:www /path/to/owncloud/
+  ::
+  
+    #!/bin/bash
+    # Sets permissions of the owncloud instance for updating
     
-After the Updater app has run, you should re-apply the strict permissions.
+    ocpath='/var/www/owncloud'
+    htuser='www-data'
+    htgroup='www-data'
+    
+    chown -R ${htuser}:${htgroup} ${ocpath}
+    
+
+Preparing the instance after upgrading
+--------------------------------------
+
+Please use the script described in :ref:`strong_perms_label` in the "Installation Wizard" document.
+
+If you have customized your ownCloud installation and your filepaths are different than the standard installation, then modify the scripts accordingly.


### PR DESCRIPTION
Based on the experience I had with https://github.com/owncloud/core/issues/21722
I reviewed the sections in the documentation and did some adoptions.

In a nutshell:
- I referenced in admin_manual/installation/installation_wizard.rst the section admin_manual/maintenance/update.rst
- I added two scripts in the ``Setting Strong Permissions`` in admin_manual/maintenance/update.rst

The second item eases the upgrade process because you just need to run script 1 to prepare the instance for the upgrade, do the upgrade and then run script 2 to reset strong permissions.

@RealRancor @nickvergessen 