### PR TITLE
Add mime.types include in location ~* \.(?:css|js)$

### DIFF
--- a/admin_manual/installation/nginx_configuration.rst
+++ b/admin_manual/installation/nginx_configuration.rst
@@ -112,6 +112,7 @@ Nginx Configuration
     # Adding the cache control header for js and css files
     # Make sure it is BELOW the location ~ \.php(?:$|/) { block
     location ~* \.(?:css|js)$ {
+      include /etc/nginx/mime.types; 
       add_header Cache-Control "public, max-age=7200";
       # Add headers to serve security related headers
       add_header Strict-Transport-Security "max-age=15768000; includeSubDomains; preload;";


### PR DESCRIPTION
Hello,

I just installed Owncloud 8.2.2 in archlinux following all the steps in the archlinux wiki and **doc.owncloud.org** and I had a small issue.

Once I configured nginx webserver + php-fpm socket I tried to access https://localhost/owncloud and I got this errors in my Chrome console (also happens in Firefox):

```
Resource interpreted as Stylesheet but transferred with MIME type text/plain: "https:///core/css/styles.css?v=fa9b0536472c7e6ce28a5a7d8703afc7".
localhost/:17 Resource interpreted as Stylesheet but transferred with MIME type text/plain: "https://localhost/core/css/header.css?v=fa9b0536472c7e6ce28a5a7d8703afc7".
localhost/:18 Resource interpreted as Stylesheet but transferred with MIME type text/plain: "https://localhost/core/css/mobile.css?v=fa9b0536472c7e6ce28a5a7d8703afc7".
localhost/:20 Resource interpreted as Stylesheet but transferred with MIME type text/plain: "https://localhost/core/css/fonts.css?v=fa9b0536472c7e6ce28a5a7d8703afc7".
localhost/:19 Resource interpreted as Stylesheet but transferred with MIME type text/plain: "https://localhost/core/css/icons.css?v=fa9b0536472c7e6ce28a5a7d8703afc7".
localhost/:22 Resource interpreted as Stylesheet but transferred with MIME type text/plain: "https://localhost/core/css/fixes.css?v=fa9b0536472c7e6ce28a5a7d8703afc7".
localhost/:21 Resource interpreted as Stylesheet but transferred with MIME type text/plain: "https://localhost/core/css/apps.css?v=fa9b0536472c7e6ce28a5a7d8703afc7".
localhost/:23 Resource interpreted as Stylesheet but transferred with MIME type text/plain: "https://localhost/core/css/multiselect.css?v=fa9b0536472c7e6ce28a5a7d8703afc7".
localhost/:25 Resource interpreted as Stylesheet but transferred with MIME type text/plain: "https://localhost/core/css/jquery-ui-fixes.css?v=fa9b0536472c7e6ce28a5a7d8703afc7".
localhost/:26 Resource interpreted as Stylesheet but transferred with MIME type text/plain: "https://localhost/core/css/tooltip.css?v=fa9b0536472c7e6ce28a5a7d8703afc7".
localhost/:27 Resource interpreted as Stylesheet but transferred with MIME type text/plain: "https://localhost/core/vendor/strengthify/strengthify.css?v=fa9b0536472c7e6ce28a5a7d8703afc7".
localhost/:28 Resource interpreted as Stylesheet but transferred with MIME type text/plain: "https://localhost/core/css/jquery.ocdialog.css?v=fa9b0536472c7e6ce28a5a7d8703afc7".
localhost/:24 Resource interpreted as Stylesheet but transferred with MIME type text/plain: "https://localhost/core/vendor/jquery-ui/themes/base/jquery-ui.css?v=fa9b0536472c7e6ce28a5a7d8703afc7".
localhost/:1 Refused to execute script from 'https://localhost/core/vendor/jquery/jquery.min.js?v=fa9b0536472c7e6ce28a5a7d8703afc7' because its MIME type ('text/plain') is not executable, and strict MIME type checking is enabled.
localhost/:1 Refused to execute script from 'https://localhost/core/vendor/jquery-migrate/jquery-migrate.min.js?v=fa9b0536472c7e6ce28a5a7d8703afc7' because its MIME type ('text/plain') is not executable, and strict MIME type checking is enabled.
localhost/:1 Refused to execute script from 'https://localhost/core/vendor/jquery-ui/ui/jquery-ui.custom.js?v=fa9b0536472c7e6ce28a5a7d8703afc7' because its MIME type ('text/plain') is not executable, and strict MIME type checking is enabled.
localhost/:1 Refused to execute script from 'https://localhost/core/vendor/underscore/underscore.js?v=fa9b0536472c7e6ce28a5a7d8703afc7' because its MIME type ('text/plain') is not executable, and strict MIME type checking is enabled.
localhost/:1 Refused to execute script from 'https://localhost/core/vendor/moment/min/moment-with-locales.js?v=fa9b0536472c7e6ce28a5a7d8703afc7' because its MIME type ('text/plain') is not executable, and strict MIME type checking is enabled.
localhost/:1 Refused to execute script from 'https://localhost/core/vendor/handlebars/handlebars.js?v=fa9b0536472c7e6ce28a5a7d8703afc7' because its MIME type ('text/plain') is not executable, and strict MIME type checking is enabled.
localhost/:1 Refused to execute script from 'https://localhost/core/vendor/blueimp-md5/js/md5.js?v=fa9b0536472c7e6ce28a5a7d8703afc7' because its MIME type ('text/plain') is not executable, and strict MIME type checking is enabled.
localhost/:1 Refused to execute script from 'https://localhost/core/vendor/bootstrap/js/tooltip.js?v=fa9b0536472c7e6ce28a5a7d8703afc7' because its MIME type ('text/plain') is not executable, and strict MIME type checking is enabled.
localhost/:1 Refused to execute script from 'https://localhost/core/vendor/backbone/backbone.js?v=fa9b0536472c7e6ce28a5a7d8703afc7' because its MIME type ('text/plain') is not executable, and strict MIME type checking is enabled.
localhost/:1 Refused to execute script from 'https://localhost/core/js/placeholders.js?v=fa9b0536472c7e6ce28a5a7d8703afc7' because its MIME type ('text/plain') is not executable, and strict MIME type checking is enabled.
localhost/:1 Refused to execute script from 'https://localhost/core/js/compatibility.js?v=fa9b0536472c7e6ce28a5a7d8703afc7' because its MIME type ('text/plain') is not executable, and strict MIME type checking is enabled.
localhost/:1 Refused to execute script from 'https://localhost/core/js/jquery.ocdialog.js?v=fa9b0536472c7e6ce28a5a7d8703afc7' because its MIME type ('text/plain') is not executable, and strict MIME type checking is enabled.
localhost/:1 Refused to execute script from 'https://localhost/core/js/oc-dialogs.js?v=fa9b0536472c7e6ce28a5a7d8703afc7' because its MIME type ('text/plain') is not executable, and strict MIME type checking is enabled.
localhost/:1 Refused to execute script from 'https://localhost/core/js/js.js?v=fa9b0536472c7e6ce28a5a7d8703afc7' because its MIME type ('text/plain') is not executable, and strict MIME type checking is enabled.
localhost/:1 Refused to execute script from 'https://localhost/core/js/l10n.js?v=fa9b0536472c7e6ce28a5a7d8703afc7' because its MIME type ('text/plain') is not executable, and strict MIME type checking is enabled.
localhost/:1 Refused to execute script from 'https://localhost/core/l10n/es.js?v=fa9b0536472c7e6ce28a5a7d8703afc7' because its MIME type ('text/plain') is not executable, and strict MIME type checking is enabled.
localhost/:1 Refused to execute script from 'https://localhost/core/js/octemplate.js?v=fa9b0536472c7e6ce28a5a7d8703afc7' because its MIME type ('text/plain') is not executable, and strict MIME type checking is enabled.
localhost/:1 Refused to execute script from 'https://localhost/core/js/eventsource.js?v=fa9b0536472c7e6ce28a5a7d8703afc7' because its MIME type ('text/plain') is not executable, and strict MIME type checking is enabled.
localhost/:1 Refused to execute script from 'https://localhost/core/js/config.js?v=fa9b0536472c7e6ce28a5a7d8703afc7' because its MIME type ('text/plain') is not executable, and strict MIME type checking is enabled.
localhost/:1 Refused to execute script from 'https://localhost/core/search/js/search.js?v=fa9b0536472c7e6ce28a5a7d8703afc7' because its MIME type ('text/plain') is not executable, and strict MIME type checking is enabled.
localhost/:1 Refused to execute script from 'https://localhost/core/js/oc-requesttoken.js?v=fa9b0536472c7e6ce28a5a7d8703afc7' because its MIME type ('text/plain') is not executable, and strict MIME type checking is enabled.
localhost/:1 Refused to execute script from 'https://localhost/core/js/apps.js?v=fa9b0536472c7e6ce28a5a7d8703afc7' because its MIME type ('text/plain') is not executable, and strict MIME type checking is enabled.
localhost/:1 Refused to execute script from 'https://localhost/core/js/mimetype.js?v=fa9b0536472c7e6ce28a5a7d8703afc7' because its MIME type ('text/plain') is not executable, and strict MIME type checking is enabled.
localhost/:1 Refused to execute script from 'https://localhost/core/js/mimetypelist.js?v=fa9b0536472c7e6ce28a5a7d8703afc7' because its MIME type ('text/plain') is not executable, and strict MIME type checking is enabled.
localhost/:1 Refused to execute script from 'https://localhost/core/vendor/snapjs/dist/latest/snap.js?v=fa9b0536472c7e6ce28a5a7d8703afc7' because its MIME type ('text/plain') is not executable, and strict MIME type checking is enabled.
localhost/:1 Refused to execute script from 'https://localhost/core/vendor/backbone/backbone.js?v=fa9b0536472c7e6ce28a5a7d8703afc7' because its MIME type ('text/plain') is not executable, and strict MIME type checking is enabled.
localhost/:1 Refused to execute script from 'https://localhost/core/js/oc-backbone.js?v=fa9b0536472c7e6ce28a5a7d8703afc7' because its MIME type ('text/plain') is not executable, and strict MIME type checking is enabled.
localhost/:1 Refused to execute script from 'https://localhost/core/js/placeholder.js?v=fa9b0536472c7e6ce28a5a7d8703afc7' because its MIME type ('text/plain') is not executable, and strict MIME type checking is enabled.
localhost/:1 Refused to execute script from 'https://localhost/core/js/jquery.avatar.js?v=fa9b0536472c7e6ce28a5a7d8703afc7' because its MIME type ('text/plain') is not executable, and strict MIME type checking is enabled.
localhost/:1 Refused to execute script from 'https://localhost/core/js/avatar.js?v=fa9b0536472c7e6ce28a5a7d8703afc7' because its MIME type ('text/plain') is not executable, and strict MIME type checking is enabled.
localhost/:1 Refused to execute script from 'https://localhost/core/vendor/strengthify/jquery.strengthify.js?v=fa9b0536472c7e6ce28a5a7d8703afc7' because its MIME type ('text/plain') is not executable, and strict MIME type checking is enabled.
localhost/:1 Refused to execute script from 'https://localhost/core/js/setup.js?v=fa9b0536472c7e6ce28a5a7d8703afc7' because its MIME type ('text/plain') is not executable, and strict MIME type checking is enabled.
localhost/:1 Refused to execute script from 'https://localhost/core/js/jquery-showpassword.js?v=fa9b0536472c7e6ce28a5a7d8703afc7' because its MIME type ('text/plain') is not executable, and strict MIME type checking is enabled.
localhost/:1 Refused to execute script from 'https://localhost/core/js/installation.js?v=fa9b0536472c7e6ce28a5a7d8703afc7' because its MIME type ('text/plain') is not executable, and strict MIME type checking is enabled.
```

Adding include **/etc/nginx/mime.types;** in the block **location ~* \.(?:css|js)$** did the trick.

Regards.