### PR TITLE
redis for distros that do not support correct version

### DIFF
--- a/admin_manual/configuration_server/caching_configuration.rst
+++ b/admin_manual/configuration_server/caching_configuration.rst
@@ -7,8 +7,8 @@ caching, where frequently-requested objects are stored in memory for faster
 retrieval. There are two types of caches to use: a PHP opcode cache, which is 
 commonly called *opcache*, and data caching for your Web server. If you do not 
 install and enable a local memcache you will see a warning on your ownCloud 
-admin page. A memcache is not required and you may ignore the warning if you 
-prefer.
+admin page. **A memcache is not required and you may safely ignore the warning 
+if you prefer.**
 
 .. note:: If you enable only a distributed cache in 
    your ``config.php`` (``memcache.distributed``) and not a 
@@ -16,7 +16,7 @@ prefer.
 
 A PHP opcache stores compiled PHP scripts so they don't need to be re-compiled 
 every time they are called. PHP bundles the Zend OPcache in core since version 
-5.5, so you don't need to install an opcache.
+5.5, so you don't need to install an opcache for PHP 5.5+.
 
 If you are using PHP 5.4, which is the oldest supported PHP version for 
 ownCloud, you may install the Alternative PHP Cache (APC). This is both an 
@@ -38,11 +38,6 @@ of memcache that best fits your needs. The supported caching backends are:
    Distributed cache for multi-server ownCloud installations.
 * `Redis <http://redis.io/>`_, PHP module 2.2.5 and up required.
    For distributed caching.
-
-These are supported but not recommended:
-
-* `XCache <http://xcache.lighttpd.net/>`_ 
-* `ArrayCache <http://www.arbylon.net/projects/knowceans-tools/doc/org/knowceans/util/ArrayCache.html>`_
    
 Memcaches must be explicitly configured in ownCloud 8.1 and up by installing 
 and enabling your desired cache, and then adding the appropriate entry to 
@@ -74,7 +69,7 @@ Refresh your ownCloud admin page, and the cache warning should disappear.
 APCu
 ----
 
-PHP 5.5 and up includes the Zend OPcache in core, and on most Linux 
+PHP 5.5 and up include the Zend OPcache in core, and on most Linux 
 distributions it is enabled by default. However, it does 
 not bundle a data cache. APCu is a data cache, and it is available in most 
 Linux distributions. On Red Hat/CentOS/Fedora systems running PHP 5.5 and up 
@@ -87,23 +82,7 @@ After restarting your Web server, add this line to your ``config.php`` file::
 
  'memcache.local' => '\OC\Memcache\APCu',
  
-Refresh your ownCloud admin page, and the cache warning should disappear.
-
-.. finish this later. too vexing to bother with now.
-.. Enabling PHP opcache
-.. ^^^^^^^^^^^^^^^^^^^^
-..
-.. Use :ref:`label-phpinfo` to see if your PHP opcache is already enabled by 
-.. searching for ``opcache.enable``. If it says ``on`` then it is enabled and 
-.. you don't need to do anything. Figure 1 is from Linux Mint 17; the Zend 
-.. OPcache is enabled by default and ``phpinfo`` displays status and statistics.
-..
-.. .. figure:: images/cache-1.png
-..   :alt: The Zend OPcache section displays opcode cache status and statistics.
-..  
-..   *Figure 1: Zend OPcache status in phpinfo*
-..   
-.. If it is not enabled, then go into    
+Refresh your ownCloud admin page, and the cache warning should disappear.  
 
 Memcached
 ---------
@@ -112,7 +91,7 @@ Memcached is a reliable oldtimer for shared caching on distributed servers,
 and performs well with ownCloud with one exception: it is not suitable to use 
 with :doc:`Transactional File Locking <../configuration_files/files_locking_transactional>`
 because it does not store locks, and data can disappear from the cache at any time
-(Redis is the best for this). 
+(Redis is the best memcache for this). 
 
 .. note:: Be sure to install the **memcached** PHP module, and not memcache, as 
    in the following examples. ownCloud supports only the **memcached** PHP 
@@ -154,13 +133,15 @@ as a local cache for :doc:`Transactional File Locking
 <../configuration_files/files_locking_transactional>` because it guarantees 
 that cached objects are available for as long as they are needed.
 
-The Redis PHP module must be version 2.2.5 and up.
+The Redis PHP module must be version 2.2.5+. If you are running a Linux 
+distribution that does not package the supported versions of this module, or 
+does not package Redis at all, see :ref:`install_redis_label`.
 
 On Debian/Ubuntu/Mint install ``redis-server`` and ``php5-redis``. The installer 
 will automatically launch ``redis-server`` and configure it to launch at 
 startup.
 
-On Red Hat/CentOS/Fedora install ``redis`` and ``php-pecl-redis``. It will not 
+On CentOS and Fedora install ``redis`` and ``php-pecl-redis``. It will not 
 start automatically, so you must use your service manager to start 
 ``redis``, and to launch it at boot as a daemon.
  
@@ -177,17 +158,13 @@ Redis for the local server cache::
   'redis' => array(
        'host' => 'localhost',
        'port' => 6379,
-       'password' => '', // Optional, if not defined no password will be used.
         ),
 
 For best performance, use Redis for file locking by adding this::
 
   'memcache.locking' => '\OC\Memcache\Redis',
 
-.. note:: For enhanced security it is recommended to configure Redis to require
-   a password. See http://redis.io/topics/security for more information.
-
-If you want to connect to Redis configured to listen on an unix socket (which is
+If you want to connect to Redis configured to listen on an Unix socket (which is
 recommended if Redis is running on the same system as ownCloud) use this example
 ``config.php`` configuration::
 
@@ -198,10 +175,7 @@ recommended if Redis is running on the same system as ownCloud) use this example
         ),
 
 Redis is very configurable; consult `the Redis documentation 
-<http://redis.io/documentation>`_ to learn more. 
-
-If you are on Ubuntu you can follow `this guide 
-<https://www.techandme.se/how-to-configure-redis-cache-in-ubuntu-14-04-with-owncloud/>`_ for a complete installation from scratch. 
+<http://redis.io/documentation>`_ to learn more.
 
 Cache Directory Location
 ------------------------
@@ -210,17 +184,17 @@ The cache directory defaults to ``data/$user/cache`` where ``$user`` is the
 current user. You may use the ``'cache_path'`` directive in ``config.php``
 (See :doc:`config_sample_php_parameters`) to select a different location.
 
-Recommendation Based on Type of Deployment
-------------------------------------------
+Recommendations Based on Type of Deployment
+-------------------------------------------
 
-Small/private home server
+Small/Private Home Server
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Only use APCu::
 
     'memcache.local' => '\OC\Memcache\APCu',
 
-Small organization, single-server setup
+Small Organization, Single-server Setup
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Use APCu for local caching, Redis for file locking::
@@ -232,7 +206,7 @@ Use APCu for local caching, Redis for file locking::
        'port' => 6379,
         ),
 
-Large organization, clustered setup
+Large Organization, Clustered Setup
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Use Redis for everything except local memcache::
@@ -244,3 +218,36 @@ Use Redis for everything except local memcache::
        'host' => 'localhost',
        'port' => 6379,
         ),
+
+..  _install_redis_label:     
+        
+Additional Redis Installation Help
+----------------------------------
+
+If your version of Mint or Ubuntu does not package the required version of 
+``php5-redis``, then try `this Redis guide on Tech and Me 
+<https://www.techandme.se/how-to-configure-redis-cache-in-ubuntu-14-04-with-
+owncloud/>`_ for a complete Redis installation on Ubuntu 14.04 using PECL. 
+These instructions are adaptable for any distro that does not package the 
+supported version, or that does not package Redis at all, such as SUSE Linux 
+Enterprise Server and Red Hat Enterprise Linux.
+
+The Redis PHP module must be at least version 2.2.5. Please note that 
+the Redis PHP module versions 2.2.5 - 2.2.7 will only work for:
+  
+.. code-block:: bash
+   
+   PHP version 6.0.0 or older
+   PHP version 5.2.0 or newer
+  
+See `<https://pecl.php.net/package/redis>`_
+
+On Debian/Mint/Ubuntu, use ``apt-cache`` to see the available 
+``php5-redis`` version, or the version of your installed package::
+
+ apt-cache policy php5-redis
+ 
+On CentOS and Fedora, the ``yum`` command shows available and installed version 
+information::
+
+ yum find php-pecl-redis


### PR DESCRIPTION
This update relies on @enoch85's excellent howto  https://www.techandme.se/how-to-configure-redis-cache-in-ubuntu-14-04-with-owncloud/  Anyone who wants to write up distro-specific instructions, for example for SLES and RHEL, which do not package Redis, please put them in the documentation Wiki.  And please please PLEASE test your instructions before posting. I can write wrong ones without help :)

This PR replaces  https://github.com/owncloud/documentation/pull/2042/, https://github.com/owncloud/documentation/issues/2043, and https://github.com/owncloud/documentation/pull/2000