### PR TITLE
Use path instead of app id for occ app signing

### DIFF
--- a/developer_manual/app/code_signing.rst
+++ b/developer_manual/app/code_signing.rst
@@ -125,9 +125,9 @@ examples will assume that you are trying to sign an application named
    secret and not disclose it to any third-parties.
 3. ownCloud will provide you with the signed certificate.
 4. Run ``./occ integrity:sign-app`` to sign your application, and specify 
-   your private and the public key. A valid example looks like: ``./occ 
-   integrity:sign-app --privateKey=/Users/lukasreschke/contacts.key 
-   --certificate=/Users/lukasreschke/CA/contacts.crt --appId=contacts``
+   your private and the public key as well as the path to the application. 
+   A valid example looks like: ``./occ integrity:sign-app --privateKey=/Users/lukasreschke/contacts.key 
+   --certificate=/Users/lukasreschke/CA/contacts.crt --path=/Users/lukasreschke/Programming/contacts``
 
 The occ tool will store a ``signature.json`` file within the ``appinfo`` folder 
 of your application. Then compress the application folder and upload it to 

--- a/go.php
+++ b/go.php
@@ -28,6 +28,7 @@ $mapping = array(
     'admin-setup-well-known-URL' => '/admin_manual/issues/general_troubleshooting.html#service-discovery',
 
     'developer-theming'       => '/developer_manual/core/theming.html',
+    'developer-code-integrity'=> '/developer_manual/app/code_signing.html',
 
     'user-encryption'         => '/user_manual/files/encrypting_files.html',
     'user-files'              => '/user_manual/files/index.html',


### PR DESCRIPTION
Use --path instead of --appId

Requires https://github.com/owncloud/core/pull/21816