### PR TITLE
Don't mention obsolete htscanner extension.

### DIFF
--- a/admin_manual/configuration_files/big_file_upload_configuration.rst
+++ b/admin_manual/configuration_files/big_file_upload_configuration.rst
@@ -31,10 +31,9 @@ System Configuration
 Configuring Your Webserver
 --------------------------
 
-| ownCloud comes with its own ``owncloud/.htaccess`` file.
-| If PHP-FPM is used, it can't read ``.htaccess`` PHP settings unless the ``htscanner``
-| PECL extension is installed. If PHP-FPM is used without this PECL extension installed,
-| settings and permissions must be set in the ``owncloud/.user.ini`` file.
+| ownCloud comes with its own ``owncloud/.htaccess`` file. Because ``php-fpm`` can't 
+| read PHP settings in ``.htaccess`` these settings and permissions must be set
+| in the ``owncloud/.user.ini`` file.
 
 Set the following two parameters inside the corresponding php.ini file (see the 
 **Loaded Configuration File** section of :ref:`label-phpinfo` to find your 

--- a/admin_manual/installation/source_installation.rst
+++ b/admin_manual/installation/source_installation.rst
@@ -405,10 +405,9 @@ server in order for these changes to be applied.
 
 **.htaccess notes for webservers \<> Apache**
 
-ownCloud comes with its own ``owncloud/.htaccess`` file. ``php-fpm`` can't 
-read PHP settings in ``.htaccess`` unless the ``htscanner`` PECL extension is 
-installed. If ``php-fpm`` is used without this PECL extension installed, 
-settings and permissions must be set in the ``owncloud/.user.ini`` file.
+ownCloud comes with its own ``owncloud/.htaccess`` file. Because ``php-fpm`` can't 
+read PHP settings in ``.htaccess`` these settings and permissions must be set
+in the ``owncloud/.user.ini`` file.
 
 .. _other_HTTP_servers_label:
 


### PR DESCRIPTION
PHP supports the .user.ini since PHP 5.3.0 (see https://secure.php.net/manual/en/configuration.file.per-user.php) and the htscanner extension is obsolete since then. It makes no sense to mention this obsolete extension in those docs.