### PR TITLE
Fix missing newline for TODO tag.

### DIFF
--- a/developer_manual/general/devenv.rst
+++ b/developer_manual/general/devenv.rst
@@ -12,6 +12,7 @@ Set up web server and database
 ==============================
 
 First `set up your web server and database <https://doc.owncloud.org/server/9.0/admin_manual/#installation>`_ (**Section**: Manual Installation - Prerequisites).
+
 .. TODO ON RELEASE: Update version number above on release
 
 Get the source


### PR DESCRIPTION
Currently showing the TODO tag on https://doc.owncloud.org/server/9.0/developer_manual/general/devenv.html