### PR TITLE
Source installation: optional PHP module pcntl (II)

### DIFF
--- a/admin_manual/installation/source_installation.rst
+++ b/admin_manual/installation/source_installation.rst
@@ -40,7 +40,9 @@ Prerequisites
 The ownCloud .tar archive contains all of the required PHP modules. This section 
 lists all required and optional PHP modules.  Consult the `PHP manual 
 <http://php.net/manual/en/extensions.php>`_ for more information on modules. 
-Your Linux distribution should have packages for all required modules.
+Your Linux distribution should have packages for all required modules. You can 
+check the precense of a module by typing ``php -m | grep -i <module_name>``. 
+If you get a result, the module is present.
 
 Required:
 
@@ -105,6 +107,10 @@ For preview generation (*optional*):
 * PHP module imagick
 * avconv or ffmpeg
 * OpenOffice or LibreOffice
+
+For command line processing (*optional*):
+
+* PHP module pcntl (enables command interruption by pressing ``ctrl-c``)
 
 You don’t need the WebDAV module for your Web server (i.e. Apache’s 
 ``mod_webdav``), as ownCloud has a built-in WebDAV server of its own, SabreDAV. 


### PR DESCRIPTION
Update the optional PHP module list with ``pcntl``
``pcntl`` functions are used in occ commands for user interruption.
optional, because the logic checks availability and passes by if not present
Used in https://github.com/owncloud/core/pull/21701 occ scan:files Adding more details in the base print out (II) 
Other occ commands to use this php functions are on the way
@RealRancor closing the other PR, easier to create a new one
@oparoz for your info