### PR TITLE
encryption:migrate is encryption:migrate-keys in 8.0

### DIFF
--- a/admin_manual/configuration_files/encryption_configuration.rst
+++ b/admin_manual/configuration_files/encryption_configuration.rst
@@ -13,7 +13,7 @@ with.
 .. note:: When you upgrade from older versions of ownCloud to ownCloud 8.0, you 
    must manually migrate your encryption keys with the *occ* command after the 
    upgrade is complete, like this example for CentOS:
-   *sudo -u apache php occ encryption:migrate*
+   *sudo -u apache php occ encryption:migrate-keys*
    You must run *occ* as your HTTP user. See 
    :doc:`../configuration_server/occ_command` to learn more about *occ*
 

--- a/admin_manual/configuration_server/occ_command.rst
+++ b/admin_manual/configuration_server/occ_command.rst
@@ -144,7 +144,7 @@ Encryption
 When you are using encryption, you must manually migrate your encryption 
 keys after upgrading your ownCloud server::
 
- $ sudo -u www-data php occ encryption:migrate
+ $ sudo -u www-data php occ encryption:migrate-keys
 
 File Operations
 ---------------

--- a/admin_manual/maintenance/update.rst
+++ b/admin_manual/maintenance/update.rst
@@ -34,7 +34,7 @@ and data, and it automates updating
    versions of ownCloud to ownCloud 8.0, you must manually migrate your 
    encryption keys with the *occ* command after the upgrade is complete, like 
    this example for CentOS:
-   *sudo -u apache php occ encryption:migrate*
+   *sudo -u apache php occ encryption:migrate-keys*
    You must run *occ* as your HTTP user. See 
    :doc:`../configuration_server/occ_command` to learn more about *occ*
 

--- a/admin_manual/maintenance/upgrade.rst
+++ b/admin_manual/maintenance/upgrade.rst
@@ -55,7 +55,15 @@ complete the upgrade. These are the basic steps to upgrading ownCloud:
 * Log in and :ref:`apply strong permissions <strong_perms_label>` to your 
   ownCloud directories.
 * Re-enable third-party apps.
-   
+
+.. note:: If you are using the Encryption app and upgrading from older 
+   versions of ownCloud to ownCloud 8.0, you must manually migrate your 
+   encryption keys with the *occ* command after the upgrade is complete, like 
+   this example for CentOS:
+   *sudo -u apache php occ encryption:migrate-keys*
+   You must run *occ* as your HTTP user. See 
+   :doc:`../configuration_server/occ_command` to learn more about *occ*
+
 Prerequisites
 -------------
 

--- a/admin_manual/release_notes.rst
+++ b/admin_manual/release_notes.rst
@@ -44,7 +44,7 @@ Manually Migrate Encryption Keys after Upgrade
 If you are using the Encryption app and upgrading from older versions of 
 ownCloud to ownCloud 8.0, you must manually migrate your encryption keys with 
 the *occ* command after the upgrade is complete, like this example for CentOS: 
-*sudo -u apache php occ encryption:migrate* You must run *occ* as your HTTP 
+*sudo -u apache php occ encryption:migrate-keys* You must run *occ* as your HTTP 
 user. See :doc:`../configuration_server/occ_command` to learn more about *occ*
 
 Windows Server Not Supported


### PR DESCRIPTION
Ref: https://github.com/owncloud/documentation/issues/1583#issuecomment-180268694

Also re-added the note about encryption migration to the quickstart.