### PR TITLE
Updated section on Apache w/ mod_fcgid with info on FcgidMaxRequestInMem

### DIFF
--- a/admin_manual/configuration_files/big_file_upload_configuration.rst
+++ b/admin_manual/configuration_files/big_file_upload_configuration.rst
@@ -64,7 +64,16 @@ Apache
 
 Apache with mod_fcgid
 ^^^^^^^^^^^^^^^^^^^^^
+* `FcgidMaxRequestInMem <https://httpd.apache.org/mod_fcgid/mod/mod_fcgid.html#fcgidmaxrequestinmem>`_
 * `FcgidMaxRequestLen <https://httpd.apache.org/mod_fcgid/mod/mod_fcgid.html#fcgidmaxrequestlen>`_
+
+.. note:: If you are using Apache/2.4 with mod_fcgid, as of February/March 2016,
+   ``FcgidMaxRequestInMem`` still needs to be significantly increased from its default value
+   to avoid the occurence of segmentation faults when uploading big files. This is not a regular
+   setting but serves as a workaround for `Apache with mod_fcgid bug #51747 <https://bz.apache.org/bugzilla/show_bug.cgi?id=51747>`_.
+   
+   Setting ``FcgidMaxRequestInMem`` significantly higher than normal may no longer be
+   necessary, once bug #51747 is fixed.
 
 nginx
 ^^^^^


### PR DESCRIPTION
Quintessence of [ownCloud issue #22036](https://github.com/owncloud/core/issues/22036): ``FcgidMaxRequestInMem`` still needs to be significantly increased from its default value to avoid the occurence of segmentation faults when uploading big files, which is not a regular setting but serves as a workaround for [Apache with mod_fcgid bug #51747](https://bz.apache.org/bugzilla/show_bug.cgi?id=51747).