### PR TITLE
Only disable "Use SSL" when the server is HTTP only

### DIFF
--- a/user_manual/pim/sync_ios.rst
+++ b/user_manual/pim/sync_ios.rst
@@ -19,7 +19,7 @@ Calendar
 
    -  Select OK.
    -  Select advanced settings.
-   -  Make sure Use SSL is set to OFF.
+   -  If your server does not support SSL, make sure Use SSL is set to OFF.
    -  Change port to 80.
    -  Go back to account information and hit Save.
 
@@ -44,7 +44,7 @@ Address book
 
    -  Select OK.
    -  Select advanced settings.
-   -  Make sure Use SSL is set to OFF.
+   -  If your server does not support SSL, make sure Use SSL is set to OFF.
    -  Change port to 80.
    -  Go back to account information and hit Save.
 


### PR DESCRIPTION
Confirmed by @LukasReschke 

@carlaschroder can you make sure to backport this to any version that has this step?