### PR TITLE
convert named code blocks to generic code blocks

### DIFF
--- a/admin_manual/configuration_database/db_conversion.rst
+++ b/admin_manual/configuration_database/db_conversion.rst
@@ -15,7 +15,7 @@ Run the conversion
 First setup the new database, here called "new_db_name".
 In ownCloud root folder call
 
-.. code-block:: bash
+::
 
   php occ db:convert-type [options] type username hostname database
 
@@ -32,7 +32,7 @@ apps will not be converted even with option ``--all-apps``
 
 For example
 
-.. code-block:: bash
+::
 
   php occ db:convert-type --all-apps mysql oc_mysql_user 127.0.0.1 new_db_name
 
@@ -48,7 +48,7 @@ Unconvertible Tables
 If you updated your ownCloud installation there might exist old tables, which 
 are not used anymore. The converter will tell you which ones.
 
-.. code-block:: bash
+::
 
 
   The following tables will not be converted:

--- a/admin_manual/configuration_database/linux_database_configuration.rst
+++ b/admin_manual/configuration_database/linux_database_configuration.rst
@@ -65,7 +65,7 @@ If you decide to use a MySQL or MariaDB database, ensure the following:
 
 The PHP configuration in :file:`/etc/php5/conf.d/mysql.ini` could look like this:
 
-.. code-block:: ini
+::
 
   # configuration for PHP MySQL module
   extension=pdo_mysql.so
@@ -94,7 +94,7 @@ To start the MySQL command line mode use::
 
 Then a **mysql>** or **MariaDB [root]>** prompt will appear. Now enter the following lines and confirm them with the enter key:
 
-.. code-block:: sql
+::
 
   CREATE USER 'username'@'localhost' IDENTIFIED BY 'password';
   CREATE DATABASE IF NOT EXISTS owncloud;
@@ -110,7 +110,7 @@ name of the database. The :file:`config/config.php` as created by the
 :doc:`../installation/installation_wizard` would therefore contain entries like
 this:
 
-.. code-block:: php
+::
 
   <?php
 
@@ -129,7 +129,7 @@ If you decide to use a PostgreSQL database make sure that you have installed
 and enabled the PostgreSQL extension in PHP. The PHP configuration in :file:`/etc/php5/conf.d/pgsql.ini` could look
 like this:
 
-.. code-block:: ini
+::
 
   # configuration for PHP PostgreSQL module
   extension=pdo_pgsql.so
@@ -150,7 +150,7 @@ To start the postgres command line mode use::
 
 Then a **template1=#** prompt will appear. Now enter the following lines and confirm them with the enter key:
 
-.. code-block:: sql
+::
 
   CREATE USER username CREATEDB;
   CREATE DATABASE owncloud OWNER username;
@@ -165,7 +165,7 @@ and an empty password to access it, and the name of the database. The :file:`con
 created by the :doc:`../installation/installation_wizard` would therefore contain entries like
 this:
 
-.. code-block:: php
+::
 
   <?php
 
@@ -189,7 +189,7 @@ To start the postgres command line mode use::
 
 Then a **postgres=#** prompt will appear. Now enter the following lines and confirm them with the enter key:
 
-.. code-block:: sql
+::
 
   CREATE USER username WITH PASSWORD 'password';
   CREATE DATABASE owncloud TEMPLATE template0 ENCODING 'UNICODE';
@@ -206,7 +206,7 @@ the name of the database. The :file:`config/config.php` as created by the
 :doc:`../installation/installation_wizard` would therefore contain entries like
 this:
 
-.. code-block:: php
+::
 
   <?php
 
@@ -224,7 +224,7 @@ If you are deploying to an Oracle database make sure that you have installed
 and enabled the `Oracle extension <http://php.net/manual/en/book.oci8.php>`_ in PHP. The PHP configuration in
 :file:`/etc/php5/conf.d/oci8.ini` could look like this:
 
-.. code-block:: ini
+::
 
   # configuration for PHP Oracle extension
   extension=oci8.so
@@ -233,7 +233,7 @@ Make sure that the Oracle environment has been set up for the process trying to 
 For a local Oracle XE installation this can be done by exporting the following environment variables
 (eg. in :file:`/etc/apache2/envvars` for Apache)
 
-.. code-block:: bash
+::
 
   export ORACLE_HOME=/u01/app/oracle/product/11.2.0/xe
   export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$ORACLE_HOME/lib
@@ -252,7 +252,7 @@ To start the Oracle command line mode with a DBA account use::
 
 After entering the password a **SQL>** prompt will appear. Now enter the following lines and confirm them with the enter key:
 
-.. code-block:: sql
+::
 
   CREATE USER owncloud IDENTIFIED BY password;
   ALTER USER owncloud DEFAULT TABLESPACE users
@@ -280,7 +280,7 @@ name of the database. The :file:`config/config.php` as created by the
 :doc:`../installation/installation_wizard` would therefore contain entries like
 this:
 
-.. code-block:: php
+::
 
   <?php
 

--- a/admin_manual/configuration_database/oracle_db_configuration.rst
+++ b/admin_manual/configuration_database/oracle_db_configuration.rst
@@ -37,7 +37,7 @@ Step one, if it has not already been completed by your :abbr:`DBA (DataBase Admi
 space on the Oracle instance for ownCloud.  This can be done by logging in as a
 DBA and running the script below:
 
-.. code-block:: sql
+::
 
   CREATE USER owncloud IDENTIFIED BY password;
   ALTER USER owncloud DEFAULT TABLESPACE users TEMPORARY TABLESPACE temp QUOTA unlimited ON users;
@@ -157,7 +157,7 @@ Assuming all of the steps have been followed to completion, the first run wizard
 
 The configuration file should look something like this:
 
-.. code-block:: php
+::
 
     <?php
     $CONFIG = array (

--- a/admin_manual/configuration_files/previews_configuration.rst
+++ b/admin_manual/configuration_files/previews_configuration.rst
@@ -41,7 +41,7 @@ thumbnails.
 
 Set the configuration option ``enable_previews`` in config.php to ``false``:
 
-.. code-block:: php
+::
 
   <?php
     'enable_previews' => false,
@@ -51,7 +51,7 @@ Maximum preview size:
 
 There are two configuration options to set the maximum size of a preview.
 
-.. code-block:: php
+::
 
   <?php
     'preview_max_x' => null,
@@ -61,7 +61,7 @@ By default, both options are set to null. 'Null' is equal to no limit.
 Numeric values represent the size in pixels. The following code limits previews
 to a maximum size of 100×100px:
 
-.. code-block:: php
+::
 
   <?php
     'preview_max_x' => 100,
@@ -76,21 +76,21 @@ If a lot of small pictures are stored on the ownCloud instance and the preview
 system generates blurry previews, you might want to consider setting a maximum 
 scale factor. By default, pictures are upscaled to 10 times the original size:
 
-.. code-block:: php
+::
 
   <?php
     'preview_max_scale_factor' => 10,
 
 If you want to disable scaling at all, you can set the config value to '1':
 
-.. code-block:: php
+::
 
   <?php
     'preview_max_scale_factor' => 1,
 
 If you want to disable the maximum scaling factor, you can set the config value to 'null':
 
-.. code-block:: php
+::
 
   <?php
     'preview_max_scale_factor' => null,

--- a/admin_manual/configuration_server/automatic_configuration.rst
+++ b/admin_manual/configuration_server/automatic_configuration.rst
@@ -33,7 +33,7 @@ Data Directory
 ~~~~~~~~~~~~~~
 Using the following parameter settings, the "Finish setup" screen requests database and admin credentials settings.
 
-.. code-block:: php
+::
 
     <?php
     $AUTOCONFIG = array(
@@ -45,7 +45,7 @@ SQLite Database
 ~~~~~~~~~~~~~~~
 Using the following parameter settings, the "Finish setup" screen requests data directory and admin credentials settings.
 
-.. code-block:: php
+::
 
     <?php
     $AUTOCONFIG = array(
@@ -58,7 +58,7 @@ MySQL Database
 ~~~~~~~~~~~~~~
 Using the following parameter settings, the "Finish setup" screen requests data directory and admin credentials settings.
 
-.. code-block:: php
+::
 
     <?php
     $AUTOCONFIG = array(
@@ -78,7 +78,7 @@ PostgreSQL Database
 ~~~~~~~~~~~~~~~~~~~
 Using the following parameter settings, the "Finish setup" screen requests data directory and admin credentials settings.
 
-.. code-block:: php
+::
 
     <?php
     $AUTOCONFIG = array(
@@ -99,7 +99,7 @@ All Parameters
 
 Using the following parameter settings, because all parameters are already configured in the file, the ownCloud installation skips the "Finish setup" screen.
 
-.. code-block:: php
+::
 
     <?php
     $AUTOCONFIG = array(

--- a/admin_manual/configuration_server/caching_configuration.rst
+++ b/admin_manual/configuration_server/caching_configuration.rst
@@ -235,7 +235,7 @@ Enterprise Server and Red Hat Enterprise Linux.
 The Redis PHP module must be at least version 2.2.5. Please note that 
 the Redis PHP module versions 2.2.5 - 2.2.7 will only work for:
   
-.. code-block:: bash
+::
    
    PHP version 6.0.0 or older
    PHP version 5.2.0 or newer

--- a/admin_manual/configuration_server/custom_client_repos.rst
+++ b/admin_manual/configuration_server/custom_client_repos.rst
@@ -6,7 +6,7 @@ You may configure the URLs to your own download repositories for your ownCloud
 desktop clients and mobile apps in :file:`config/config.php`. This example shows 
 the default download locations:
 
-.. code-block:: php
+::
 
   <?php
 

--- a/admin_manual/configuration_server/email_configuration.rst
+++ b/admin_manual/configuration_server/email_configuration.rst
@@ -111,7 +111,7 @@ are careful, edit these even without knowing PHP or HTML; don't touch any of the
 code, but you can edit the text portions of the messages. For example, this the 
 lost password mail template:
 
-.. code-block:: php
+::
 
   <?php
   
@@ -145,7 +145,7 @@ port 25/tcp will be used unless you change that by modifying the
 **mail_smtpport** parameter. Multiple servers can be entered, separated by
 semicolons:
 
-.. code-block:: php
+::
 
   <?php
 
@@ -155,7 +155,7 @@ semicolons:
 
 or
 
-.. code-block:: php
+::
 
   <?php
 
@@ -166,7 +166,7 @@ or
 If a malware or SPAM scanner is running on the SMTP server it might be
 necessary that you increase the SMTP timeout to e.g. 30s:
 
-.. code-block:: php
+::
 
   <?php
 
@@ -175,7 +175,7 @@ necessary that you increase the SMTP timeout to e.g. 30s:
 If the SMTP server accepts insecure connections, the default setting can be
 used:
 
-.. code-block:: php
+::
 
   <?php
 
@@ -189,7 +189,7 @@ SSL
 A secure connection will be initiated using the outdated SMTPS protocol
 which uses the port 465/tcp:
 
-.. code-block:: php
+::
 
   <?php
 
@@ -201,7 +201,7 @@ TLS
 A secure connection will be initiated using the STARTTLS protocol which
 uses the default port 25/tcp:
 
-.. code-block:: php
+::
 
   <?php
 
@@ -211,7 +211,7 @@ uses the default port 25/tcp:
 And finally it is necessary to configure if the SMTP server requires
 authentication, if not, the default values can be taken as is.
 
-.. code-block:: php
+::
 
   <?php
 
@@ -223,7 +223,7 @@ If SMTP authentication is required you have to set the required username
 and password and can optionally choose between the authentication types
 **LOGIN** (default) or **PLAIN**.
 
-.. code-block:: php
+::
 
   <?php
 
@@ -240,7 +240,7 @@ defined by the configuration settings in the **php.ini** file. (On \*nix
 systems this will most likely be Sendmail.) ownCloud should be able to send
 email out of the box.
 
-.. code-block:: php
+::
 
   <?php
 
@@ -261,7 +261,7 @@ necessary to have an installed and working email system on your \*nix server.
 The sendmail binary (**/usr/sbin/sendmail**) is usually part of that system.
 ownCloud should be able to send email out of the box.
 
-.. code-block:: php
+::
 
   <?php
 
@@ -283,7 +283,7 @@ installed and working qmail email system on your server. The sendmail binary
 (**/var/qmail/bin/sendmail**) will then be used to send email. ownCloud should
 be able to send email out of the box.
 
-.. code-block:: php
+::
 
   <?php
 
@@ -311,7 +311,7 @@ Troubleshooting
 If you are unable to send email, try turning on debugging. Do this by enabling 
 the ``mail_smtpdebug parameter`` in ``config/config.php``.
 
-.. code-block:: php
+::
 
   <?php
 
@@ -328,7 +328,7 @@ where your ownCloud installation is served.  If you have a different mail domain
 name you can override this behavior by setting the following configuration 
 parameter:
 
-.. code-block:: php
+::
 
   <?php
 
@@ -429,7 +429,7 @@ Enabling Debug Mode
 If you are unable to send email, it might be useful to activate further debug
 messages by enabling the mail_smtpdebug parameter:
 
-.. code-block:: php
+::
 
   <?php
 

--- a/admin_manual/configuration_server/harden_server.rst
+++ b/admin_manual/configuration_server/harden_server.rst
@@ -96,7 +96,7 @@ To redirect all HTTP traffic to HTTPS administrators are encouraged to issue a
 permanent redirect using the 301 status code. When using Apache this can be 
 achieved by a setting such as the following in the Apache VirtualHosts config:
 
-.. code-block:: none
+::
 
   <VirtualHost *:80>
      ServerName cloud.owncloud.com

--- a/admin_manual/configuration_server/js_css_asset_management_configuration.rst
+++ b/admin_manual/configuration_server/js_css_asset_management_configuration.rst
@@ -15,7 +15,7 @@ It is not recommended to enable asset-pipelining when using apps pulled via git.
 Parameters
 ----------
 
-.. code-block:: php
+::
 
   <?php
     $CONFIG = array (

--- a/admin_manual/configuration_server/knowledgebase_configuration.rst
+++ b/admin_manual/configuration_server/knowledgebase_configuration.rst
@@ -10,7 +10,7 @@ Parameters
 If you want to disable the ownCloud help menu item you can use the **knowledgebaseenabled** parameter inside the
 :file:`config/config.php`.
 
-.. code-block:: php
+::
 
   <?php
 

--- a/admin_manual/configuration_server/language_configuration.rst
+++ b/admin_manual/configuration_server/language_configuration.rst
@@ -15,7 +15,7 @@ codes.
 Parameters
 ----------
 
-.. code-block:: php
+::
 
   <?php
 

--- a/admin_manual/configuration_server/logging_configuration.rst
+++ b/admin_manual/configuration_server/logging_configuration.rst
@@ -33,7 +33,7 @@ date/time is written in the format "*2013-01-10T15:20:25+02:00*". By using the
 date format in the example below, the date/time format will be written in the format
 "*January 10, 2013 15:20:25*".
 
-.. code-block:: php
+::
 
     "log_type" => "owncloud",
     "logfile" => "owncloud.log",
@@ -45,7 +45,7 @@ syslog
 
 All log information will be sent to your default syslog daemon.
 
-.. code-block:: php
+::
 
     "log_type" => "syslog",
     "logfile" => "",

--- a/admin_manual/configuration_server/performance_tuning/webserver_tips.rst
+++ b/admin_manual/configuration_server/performance_tuning/webserver_tips.rst
@@ -64,7 +64,7 @@ requests to be sent over the same TCP connection. This reduces latency by as
 much as 50%. Especially in combination with the periodic checks of the sync
 client the following settings are recommended:
 
-.. code-block:: apache
+::
 
 	KeepAlive On
 	KeepAliveTimeout 100
@@ -85,7 +85,7 @@ because PHP is currently not thread safe.
 Hostname Lookups
 ^^^^^^^^^^^^^^^^
 
-.. code-block:: bash
+::
 
 	# cat /etc/httpd/conf/httpd.conf
         ...
@@ -105,7 +105,7 @@ down errors.
 .. MaxKeepAliveRequests 4096
 .. ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. .. code-block:: apache
+.. ::
 
 ..	<IfModule prefork.c>
 ..		StartServers 100
@@ -159,7 +159,7 @@ Compile Nginx with the ``nginx-cache-purge`` module
 
 1. **Preparation:**
 
-.. code-block:: bash
+::
 
     cd /opt
     wget http://nginx.org/keys/nginx_signing.key
@@ -185,7 +185,7 @@ Then run ``sudo apt-get update``
 
 2. **Download the Nginx source from the ppa repository**
 
-.. code-block:: bash
+::
 
    cd /opt
    sudo apt-get build-dep nginx
@@ -193,7 +193,7 @@ Then run ``sudo apt-get update``
 
 3. **Download module(s) to be compiled in and configure compiler arguments**
     
-.. code-block:: bash 
+:: 
    
    ls -la
     
@@ -203,7 +203,7 @@ Please replace ``{release}`` with the release downloaded::
     
 If folder "modules" is not present, do:
 
-.. code-block:: bash
+::
 
    sudo mkdir modules
    cd modules
@@ -229,7 +229,7 @@ The parameters may now look like::
 
 4. **Compile and install Nginx**
 
-.. code-block:: bash
+::
 
    cd /opt/nginx-{release}
    sudo dpkg-buildpackage -uc -b
@@ -239,7 +239,7 @@ The parameters may now look like::
 5. **Check if the compilation and installation of the ngx_cache_purge module 
    was successful**
    
-.. code-block:: bash  
+::  
 
    nginx -V 2>&1 | grep ngx_cache_purge -o
     
@@ -251,7 +251,7 @@ Show Nginx version including all features compiled and installed::
 
 6. **Mark Nginx to be blocked from further updates via apt-get**
 
-.. code-block:: bash
+::
 
    sudo dpkg --get-selections | grep nginx
     
@@ -270,13 +270,13 @@ Configure Nginx with the ``nginx-cache-purge`` module
    path that fits to your environment. Replace ``{path}`` in this example with 
    your path created:
    
-.. code-block:: bash   
+::   
    
    sudo mkdir -p /usr/local/tmp/cache   
 
 2. **Configuration**
 
-.. code-block:: bash
+::
 
    sudo vi /etc/nginx/sites-enabled/{your-ownCloud-nginx-config-file}
    
@@ -339,7 +339,7 @@ Add *inside* the ``server{}`` block, as an example of a configuration::
    
 3. **Test the configuration**
 
-.. code-block:: bash
+::
 
    sudo nginx -s reload
    

--- a/admin_manual/configuration_server/reverse_proxy_configuration.rst
+++ b/admin_manual/configuration_server/reverse_proxy_configuration.rst
@@ -60,7 +60,7 @@ via a multiple domains reverse SSL proxy
 **https://ssl-proxy.tld/domain.tld/owncloud** with the IP address **10.0.0.1**
 you can set the following parameters inside the :file:`config/config.php`.
 
-.. code-block:: php
+::
 
   <?php
   $CONFIG = array (

--- a/admin_manual/configuration_server/thirdparty_php_configuration.rst
+++ b/admin_manual/configuration_server/thirdparty_php_configuration.rst
@@ -14,7 +14,7 @@ When using third party components, keep the following parameters in mind:
 
 An example of what these parameters might look like is as follows:
 
-.. code-block:: php
+::
 
   <?php
 

--- a/admin_manual/configuration_user/user_auth_ftp_smb_imap.rst
+++ b/admin_manual/configuration_user/user_auth_ftp_smb_imap.rst
@@ -6,7 +6,7 @@ You may configure additional user backends
 in ownCloud's configuration :file:`config/config.php` using the following
 syntax:
 
-.. code-block:: php
+::
 
   <?php
 
@@ -35,7 +35,7 @@ Provides authentication against IMAP servers
 - **Dependency:** php-imap (See :doc:`../installation/source_installation`)
 - **Example:**
 
-.. code-block:: php
+::
 
   <?php
 
@@ -57,7 +57,7 @@ Provides authentication against Samba servers
 - **Dependency:** `php5-libsmbclient <https://download.owncloud.org/download/repositories/stable/owncloud/>`_
 - **Example:**
 
-.. code-block:: php
+::
 
   <?php
 
@@ -80,7 +80,7 @@ Provides authentication against FTP servers
 - **Dependency:** php-ftp (See :doc:`../installation/source_installation`)
 - **Example:**
 
-.. code-block:: php
+::
 
   <?php
 

--- a/admin_manual/configuration_user/user_provisioning_api.rst
+++ b/admin_manual/configuration_user/user_provisioning_api.rst
@@ -45,7 +45,7 @@ Example
 XML Output
 ^^^^^^^^^^
 
-.. code-block:: xml
+::
 
  <?xml version="1.0"?>
  <ocs>
@@ -83,7 +83,7 @@ Example
 XML Output
 ^^^^^^^^^^
 
-.. code-block:: xml
+::
 
   <?xml version="1.0"?>
   <ocs>
@@ -121,7 +121,7 @@ Example
 XML Output
 ^^^^^^^^^^
 
-.. code-block:: xml
+::
 
   <?xml version="1.0"?>
   <ocs>
@@ -169,7 +169,7 @@ Examples
 XML Output
 ^^^^^^^^^^
 
-.. code-block:: xml
+::
 
   <?xml version="1.0"?>
   <ocs>
@@ -204,7 +204,7 @@ Example
 XML Output
 ^^^^^^^^^^
 
-.. code-block:: xml
+::
 
   <?xml version="1.0"?>
   <ocs>
@@ -238,7 +238,7 @@ Example
 XML Output
 ^^^^^^^^^^
 
-.. code-block:: xml
+::
 
   <?xml version="1.0"?>
   <ocs>
@@ -284,7 +284,7 @@ Example
 XML Output
 ^^^^^^^^^^
 
-.. code-block:: xml
+::
 
   <?xml version="1.0"?>
   <ocs>
@@ -326,7 +326,7 @@ Example
 XML Output
 ^^^^^^^^^^
 
-.. code-block:: xml
+::
 
   <?xml version="1.0"?>
   <ocs>
@@ -367,7 +367,7 @@ Example
 XML Output
 ^^^^^^^^^^
 
-.. code-block:: xml
+::
 
   <?xml version="1.0"?>
   <ocs>
@@ -408,7 +408,7 @@ Example
 XML Output
 ^^^^^^^^^^
 
-.. code-block:: xml
+::
 
   <?xml version="1.0"?>
   <ocs>
@@ -445,7 +445,7 @@ Example
 XML Output
 ^^^^^^^^^^
 
-.. code-block:: xml
+::
 
   <?xml version="1.0"?>
   <ocs>
@@ -488,7 +488,7 @@ Example
 XML Output
 ^^^^^^^^^^
 
-.. code-block:: xml
+::
 
   <?xml version="1.0"?>
   <ocs>
@@ -531,7 +531,7 @@ Example
 XML Output
 ^^^^^^^^^^
 
-.. code-block:: xml
+::
 
   <?xml version="1.0"?>
   <ocs>
@@ -565,7 +565,7 @@ Example
 XML Output
 ^^^^^^^^^^
 
-.. code-block:: xml
+::
 
   <?xml version="1.0"?>
   <ocs>
@@ -606,7 +606,7 @@ Example
 XML Output
 ^^^^^^^^^^
 
-.. code-block:: xml
+::
 
   <?xml version="1.0"?>
   <ocs>
@@ -645,7 +645,7 @@ Example
 XML Output
 ^^^^^^^^^^
 
-.. code-block:: xml
+::
 
   <?xml version="1.0"?>
   <ocs>
@@ -685,7 +685,7 @@ Example
 XML Output
 ^^^^^^^^^^
 
-.. code-block:: xml
+::
 
   <?xml version="1.0"?>
   <ocs>
@@ -724,7 +724,7 @@ Example
 XML Output
 ^^^^^^^^^^
 
-.. code-block:: xml
+::
 
   <?xml version="1.0"?>
   <ocs>
@@ -778,7 +778,7 @@ Example
 XML Output
 ^^^^^^^^^^
 
-.. code-block:: xml
+::
 
   <?xml version="1.0"?>
   <ocs>
@@ -812,7 +812,7 @@ Example
 XML Output
 ^^^^^^^^^^
 
-.. code-block:: xml
+::
 
   <?xml version="1.0"?>
   <ocs>

--- a/admin_manual/installation/apps_management_installation.rst
+++ b/admin_manual/installation/apps_management_installation.rst
@@ -110,7 +110,7 @@ in that folder.
    shipped with ownCloud, follow this example to setup an **/apps2/** folder 
    which will be used to store all other apps.
 
-.. code-block:: php
+::
 
   <?php
 
@@ -144,7 +144,7 @@ To enable installation from your own apps store:
    This parameter is used to set the http path to the ownCloud apps store. The appstore 
    server must use :abbr:`OCS (Open Collaboration Services)`.
 
-.. code-block:: php
+::
 
   <?php
 

--- a/admin_manual/maintenance/enable_maintenance.rst
+++ b/admin_manual/maintenance/enable_maintenance.rst
@@ -18,7 +18,7 @@ You may also put your
 server into this mode by editing :file:`config/config.php`. Change 
 ``"maintenance" => false`` to ``"maintenance" => true``:
 
-.. code-block:: php
+::
 
    <?php
 

--- a/admin_manual/operations/considerations_on_monitoring.rst
+++ b/admin_manual/operations/considerations_on_monitoring.rst
@@ -45,7 +45,7 @@ call the status.php file on each ownCloud server. This file can be found in the 
 the server, which by default is /owncloud/status.php. If the server is functioning normally, the response
 looks something like this:
 
-.. code-block:: json
+::
 
     {"installed":"true","version":"6.0.0.16","versionstring":"6.0.1","edition":""}
 


### PR DESCRIPTION
The named code blocks throw build errors when building packages. They all look the same anyway.
