### PR TITLE
note that amazon ext storage supports eu frankfurt

### DIFF
--- a/admin_manual/configuration_files/external_storage/amazons3.rst
+++ b/admin_manual/configuration_files/external_storage/amazons3.rst
@@ -8,6 +8,8 @@ To connect your Amazon S3 buckets to ownCloud, you will need:
 - S3 secret key
 - Bucket name
 
+.. note:: ownCloud 8.2+ supports the EU (Frankfurt) region.
+
 In the **Folder name** field enter a local folder name for your S3 mountpoint. 
 If this does not exist it will be created.
 


### PR DESCRIPTION
Backport to 8.2 when code is merged. Fixes https://github.com/owncloud/documentation/issues/2235

For ownCloud admins, I think this brief note is all that is necessary. There is no relevant developer documentation that I can find, not in the dev manual nor on Github.

Please review @butonic @michaelstingl 