### PR TITLE
Fix type in "Transfer ownership" command

### DIFF
--- a/admin_manual/configuration_server/occ_command.rst
+++ b/admin_manual/configuration_server/occ_command.rst
@@ -625,7 +625,7 @@ entries that have no matching entries in the storage table.
 You may transfer all files and shares from one user to another. This is useful 
 before removing a user::
 
- sudo -u www-data php occfiles:transfer-ownership <source-user> 
+ sudo -u www-data php occ files:transfer-ownership <source-user>
  <destination-user>
 
 .. _files_external_label:


### PR DESCRIPTION
cc @carlaschroder 

Also some of the command require specific apps to be enabled in order to be available.
Should we add that to the docs?