### PR TITLE
Remove not existing warning in 8.2

### DIFF
--- a/admin_manual/configuration_server/security_setup_warnings.rst
+++ b/admin_manual/configuration_server/security_setup_warnings.rst
@@ -124,12 +124,3 @@ distribution
 and an heuristic is running the test which actually reproduces the bug. There
 are distributions such as RHEL/CentOS which have this backport still `pending 
 <https://bugzilla.redhat.com/show_bug.cgi?id=1241172>`_.
-
-Your Web server is not set up properly to resolve /.well-known/caldav/ or 
-/.well-known/carddav/
---------------------------------------------------------------------------------
----------------
-
-Both URLs needs to be correctly redirected to the DAV endpoint of ownCloud. 
-Please
-refer to :ref:`service-discovery-label` for more info.


### PR DESCRIPTION
This is only 9.0+