### PR TITLE
Set Strong Permissions update because of the Updater App

### DIFF
--- a/admin_manual/installation/installation_wizard.rst
+++ b/admin_manual/installation/installation_wizard.rst
@@ -144,6 +144,7 @@ replace the ``htuser`` and ``htgroup`` variables with your HTTP user and group::
  printf "Creating possible missing Directories\n"
  mkdir -p $ocpath/data
  mkdir -p $ocpath/assets
+ mkdir -p $ocpath/updater
 
  printf "chmod Files and Directories\n"
  find ${ocpath}/ -type f -print0 | xargs -0 chmod 0640
@@ -152,10 +153,11 @@ replace the ``htuser`` and ``htgroup`` variables with your HTTP user and group::
  printf "chown Directories\n"
  chown -R ${rootuser}:${htgroup} ${ocpath}/
  chown -R ${htuser}:${htgroup} ${ocpath}/apps/
+ chown -R ${htuser}:${htgroup} ${ocpath}/assets/
  chown -R ${htuser}:${htgroup} ${ocpath}/config/
  chown -R ${htuser}:${htgroup} ${ocpath}/data/
  chown -R ${htuser}:${htgroup} ${ocpath}/themes/
- chown -R ${htuser}:${htgroup} ${ocpath}/assets/
+ chown -R ${htuser}:${htgroup} ${ocpath}/updater/
 
  chmod +x ${ocpath}/occ
 


### PR DESCRIPTION
This is a fix to set the proper permissions for the updater directory when you run the Updater App.
Else you get a complaint that the directory is not writable by owncloud in the initialisation phase.
I also added mkdir updater and did a sorting of the directories for better readability.

I encounterd this when running 9.0.0.19
Should be IMHO backported.
