### PR TITLE
Add encryption migration to upgrading and encryption docs.

### DIFF
--- a/admin_manual/configuration_files/encryption_configuration.rst
+++ b/admin_manual/configuration_files/encryption_configuration.rst
@@ -271,3 +271,42 @@ their back-end password, and then, of course, notify the user and give them
 their new password.
 
 .. _upgrading_encryption_label:
+
+Encryption migration to ownCloud 8.0
+------------------------------------
+
+When you upgrade from older versions of ownCloud to ownCloud 8.0, you must manually migrate
+your encryption keys with the *occ* command after the upgrade is complete, like this
+example for CentOS: *sudo -u apache php occ encryption:migrate-keys* You must run *occ* as
+your HTTP user. See :doc:`../configuration_server/occ_command` to learn more about *occ*.
+
+Encryption migration to ownCloud 8.1
+------------------------------------
+
+The encryption backend has changed in ownCloud 8.1 again, so you must take some 
+additional steps to migrate encryption correctly. If you do not follow these 
+steps you may not be able to access your files.
+
+Before you start your upgrade, put your ownCloud server into 
+``maintenance:singleuser`` mode (See :doc:`../maintenance/enable_maintenance`.) 
+You must do this to prevent users and sync clients from accessing files before 
+you have completed your encryption migration.
+
+After your upgrade is complete, follow the steps in :ref:`enable_encryption` to 
+enable the new encryption system. Then click the **Start Migration** button on 
+your Admin page to migrate your encryption keys, or use the ``occ`` command. We 
+strongly recommend using the ``occ`` command; the **Start Migration** button is 
+for admins who do not have access to the console, for example installations on 
+shared hosting. This example is for Debian/Ubuntu Linux::
+
+ $ sudo -u www-data php occ encryption:migrate
+ 
+This example is for Red Hat/CentOS/Fedora Linux::
+
+ $ sudo -u apache php occ encryption:migrate
+ 
+You must run ``occ`` as your HTTP user; see 
+:doc:`../configuration_server/occ_command`.
+
+When you are finished, take your ownCloud server out of 
+``maintenance:singleuser`` mode.

--- a/admin_manual/maintenance/upgrade.rst
+++ b/admin_manual/maintenance/upgrade.rst
@@ -77,3 +77,10 @@ may re-enable them.
    
 .. _owncloud.org/install/:
    https://owncloud.org/install/  
+
+Encryption migration from oC 7.0 to 8.0 and 8.0 to 8.1
+------------------------------------------------------
+
+The encryption backend was changed twice between ownCloud 7.0 and 8.0 as well as
+between 8.0 and 8.1. If you're upgrading from these older versions please refer to 
+:ref:`upgrading_encryption_label` for the needed migration steps.

--- a/admin_manual/release_notes.rst
+++ b/admin_manual/release_notes.rst
@@ -111,7 +111,7 @@ anymore for most requests.
   
 When you upgrade from ownCloud 8.0, with encryption enabled, to 8.1, you must 
 enable the new encryption backend and migrate your encryption keys. See 
-:doc:`configuration_files/encryption_configuration`
+:ref:`upgrading_encryption_label`.
 
 Encryption can no longer be disabled in ownCloud 8.1. It is planned to re-add
 this feature to the command line client for a future release.
@@ -176,10 +176,8 @@ Manually Migrate Encryption Keys after Upgrade
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 If you are using the Encryption app and upgrading from older versions of 
-ownCloud to ownCloud 8.0, you must manually migrate your encryption keys with 
-the *occ* command after the upgrade is complete, like this example for CentOS: 
-*sudo -u apache php occ encryption:migrate* You must run *occ* as your HTTP 
-user. See :doc:`../configuration_server/occ_command` to learn more about *occ*
+ownCloud to ownCloud 8.0, you must manually migrate your encryption keys.
+See :ref:`upgrading_encryption_label`.
 
 Windows Server Not Supported
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Once 7.0 reaches EOL people with enabled encryption might get in trouble if they only have a look at the 8.2 or 9.0 upgrading docs so trying to add some more pointers about the needed migration steps.

The text from encryption_configuration.rst was gathered from older documentation.