### PR TITLE
Ubuntu 14.04 install APCu from backports

### DIFF
--- a/admin_manual/configuration_server/caching_configuration.rst
+++ b/admin_manual/configuration_server/caching_configuration.rst
@@ -73,13 +73,12 @@ PHP 5.5 and up include the Zend OPcache in core, and on most Linux
 distributions it is enabled by default. However, it does 
 not bundle a data cache. APCu is a data cache, and it is available in most 
 Linux distributions. On Red Hat/CentOS/Fedora systems running PHP 5.5 and up 
-install ``php-pecl-apcu``. On Debian/Ubuntu/Mint systems install ``php5-apcu``. 
-On Ubuntu 14.04LTS, APCu version is 4.0.2, which is a too old version for working with Owncloud. 
-Nevertheless, Ubuntu backports ships 4.0.7. You can simply Install it with the command: 
-``apt-get install php5-apcu/trusty-backports``
+install ``php-pecl-apcu``. On Debian/Ubuntu/Mint systems install ``php5-apcu``.
+On Ubuntu 14.04LTS, the APCu version is 4.0.2, which is too old to use with ownCloud. ownCloud requires 4.0.6+. You may install 4.0.7 from Ubuntu backports with this command::
+
+  apt-get install php5-apcu/trusty-backports
+   
 Then restart your Web server.
- 
-The version of APCu must be 4.0.6 and up.
 
 After restarting your Web server, add this line to your ``config.php`` file::
 

--- a/admin_manual/configuration_server/caching_configuration.rst
+++ b/admin_manual/configuration_server/caching_configuration.rst
@@ -74,6 +74,9 @@ distributions it is enabled by default. However, it does
 not bundle a data cache. APCu is a data cache, and it is available in most 
 Linux distributions. On Red Hat/CentOS/Fedora systems running PHP 5.5 and up 
 install ``php-pecl-apcu``. On Debian/Ubuntu/Mint systems install ``php5-apcu``. 
+On Ubuntu 14.04LTS, APCu version is 4.0.2, which is a too old version for working with Owncloud. 
+Nevertheless, Ubuntu backports ships 4.0.7. You can simply Install it with the command: 
+``apt-get install php5-apcu/trusty-backports``
 Then restart your Web server.
  
 The version of APCu must be 4.0.6 and up.


### PR DESCRIPTION
Added APCu install step for Ubuntu 14.04LTS from backports to get a Owncloud compatible 4.0.7 version