### PR TITLE
Fix label order in caching_configuration.rst

### DIFF
--- a/admin_manual/configuration_server/caching_configuration.rst
+++ b/admin_manual/configuration_server/caching_configuration.rst
@@ -221,13 +221,13 @@ Use Redis for everything except local memcache::
        'port' => 6379,
         ),
 
-..  _install_redis_label:     
-
 Additional notes for Redis vs. APCu on Memory Caching
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 APCu is faster at local caching than Redis. If you have enough memory, use APCu for Memory Caching
 and Redis for File Locking. If you are low on memory, use Redis for both.
+
+..  _install_redis_label:     
 
 Additional Redis Installation Help
 ----------------------------------


### PR DESCRIPTION
Had broken that in #2423 

The backports of #2423 already have the correct order.