### PR TITLE
Download limits on Nginx frontends

### DIFF
--- a/admin_manual/configuration_files/big_file_upload_configuration.rst
+++ b/admin_manual/configuration_files/big_file_upload_configuration.rst
@@ -91,12 +91,12 @@ wiki entry.
    performance, place these on a separate hard drive that is dedicated to 
    swap and temp storage.
    
-In case your site is behind a Nginx frontend (for example a loadbalancer): 
+If your site is behind a Nginx frontend (for example a loadbalancer): 
 
 By default, downloads will be limited to 1GB due to ``proxy_buffering`` and ``proxy_max_temp_file_size`` on the frontend.
 
 * If you can access the frontend's configuration, disable `proxy_buffering <http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_buffering>`_ or increase `proxy_max_temp_file_size <http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_max_temp_file_size>`_ from the default 1GB.
-* If you do not have have access to the frontend, set the `X-Accel-Buffering <http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_buffering>`_ header to ``add_header X-Accel-Buffering no;`` on your backend server.
+* If you do not have access to the frontend, set the `X-Accel-Buffering <http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_buffering>`_ header to ``add_header X-Accel-Buffering no;`` on your backend server.
 
 Configuring PHP
 ---------------

--- a/admin_manual/configuration_files/big_file_upload_configuration.rst
+++ b/admin_manual/configuration_files/big_file_upload_configuration.rst
@@ -90,6 +90,13 @@ wiki entry.
    the ``upload_tmp_dir`` or ``tempdirectory`` (see below). For optimal 
    performance, place these on a separate hard drive that is dedicated to 
    swap and temp storage.
+   
+In case your site is behind a Nginx frontend (for example a loadbalancer): 
+
+By default, downloads will be limited to 1GB due to ``proxy_buffering`` and ``proxy_max_temp_file_size`` on the frontend.
+
+* If you can access the frontend's configuration, disable `proxy_buffering <http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_buffering>`_ or increase `proxy_max_temp_file_size <http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_max_temp_file_size>`_ from the default 1GB.
+* If you do not have have access to the frontend, set the `X-Accel-Buffering <http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_buffering>`_ header to ``add_header X-Accel-Buffering no;`` on your backend server.
 
 Configuring PHP
 ---------------


### PR DESCRIPTION
Nginx frontend proxy servers by default limit the download size to 1 GB because of the default values of proxy_buffering and proxy_max_temp_file_size. These need to be either disabled via headers on the backend or the configuration on the frontend.