### PR TITLE
fixed typo in headline of "Enterprise Logging Apps"

### DIFF
--- a/admin_manual/enterprise_logging/index.rst
+++ b/admin_manual/enterprise_logging/index.rst
@@ -1,5 +1,5 @@
 ========================================
-Enterprise Logging Apps (Enteprise only)
+Enterprise Logging Apps (Enterprise only)
 ========================================
 
 .. toctree::


### PR DESCRIPTION
@carlaschroder just found a missing "r"