### PR TITLE
added <developer> section to documentation section

### DIFF
--- a/developer_manual/app/info.rst
+++ b/developer_manual/app/info.rst
@@ -27,6 +27,7 @@ The :file:`appinfo/info.xml` contains metadata about the app:
       <documentation>
           <user>https://doc.owncloud.org</user>
           <admin>https://doc.owncloud.org</admin>
+          <developer>https://doc.owncloud.org</developer>
       </documentation>
 
       <category>tool</category>
@@ -126,7 +127,7 @@ ownCloud allows to specify four kind of ``types``. Currently supported ``types``
 
 documentation
 -------------
-Link to 'admin' and 'user' documentation
+Link to 'admin', 'user', 'developer' documentation
 
 website
 -------


### PR DESCRIPTION
To make the documentation section complete I added the <developer> section, as the doc.owncloud.org also offers the `developer_manual` area.
Furthermore it would be very helpful for contributors to have this point of reference to find their way to the existing documentations (even if they are the `README.md` files in Github).