### PR TITLE
Added Required to documentation, website, repository, bugs

### DIFF
--- a/developer_manual/app/info.rst
+++ b/developer_manual/app/info.rst
@@ -27,7 +27,8 @@ The :file:`appinfo/info.xml` contains metadata about the app:
       <documentation>
           <user>https://doc.owncloud.org</user>
           <admin>https://doc.owncloud.org</admin>
-      </documentation>
+          <developer>https://doc.owncloud.org</developer>
+        </documentation>
 
       <category>tool</category>
 

--- a/developer_manual/app/info.rst
+++ b/developer_manual/app/info.rst
@@ -28,7 +28,7 @@ The :file:`appinfo/info.xml` contains metadata about the app:
           <user>https://doc.owncloud.org</user>
           <admin>https://doc.owncloud.org</admin>
           <developer>https://doc.owncloud.org</developer>
-        </documentation>
+      </documentation>
 
       <category>tool</category>
 

--- a/developer_manual/app/info.rst
+++ b/developer_manual/app/info.rst
@@ -126,19 +126,19 @@ ownCloud allows to specify four kind of ``types``. Currently supported ``types``
 
 documentation
 -------------
-Link to 'admin' and 'user' documentation
+**Required**: Link to 'admin' and 'user' documentation
 
 website
 -------
-Link to project web page
+**Required**: Link to project web page
 
 repository
 ----------
-Link to the version control repo
+**Required**: Link to the version control repo
 
 bugs
 ----
-Link to the bug tracker
+**Required**: Link to the bug tracker
 
 category
 --------


### PR DESCRIPTION
These sections should be **Required** as they always should exist (and with github generally automatically do). For the documentation there should be at least a stub provided, for others to join in. Therefore they should be mentioned to make it easier and faster for contributers to find the right ones.

Sorry if I might not have followed the proper way to propose this change, I just did not find a proper and obvious way to start the discussion. Therefore I thought it might be easier and faster to propose the change and then the consideration can start. As for this it was only a small thing to do, this was a reasonable choice for me. If this does not work for you please help me to find the proper way.