### PR TITLE
added location recommendations for documentation

### DIFF
--- a/developer_manual/app/info.rst
+++ b/developer_manual/app/info.rst
@@ -126,7 +126,19 @@ ownCloud allows to specify four kind of ``types``. Currently supported ``types``
 
 documentation
 -------------
-Link to 'admin' and 'user' documentation
+Link to 'developer', 'admin' and 'user' documentation
+
+Common places are: (where $name is the name of your app, e.g. $name=theapp)
+
+.. code-block:: xml
+
+  $DOCUMENTATION_BASE = 'https://doc.owncloud.org';
+  $DOCUMENTATION_DEVELOPER = $DOCUMENTATION_BASE.'/server/'.$VERSIONS_SERVER_MAJOR_DEV_DOCS.'/developer_manual/$name/';`    
+  $DOCUMENTATION_ADMIN = $DOCUMENTATION_BASE.'/server/'.$VERSIONS_SERVER_MAJOR_STABLE.'/admin_manual/$name/';
+  $DOCUMENTATION_USER = $DOCUMENTATION_BASE.'/server/'.$VERSIONS_SERVER_MAJOR_STABLE.'/user_manual/$name/';
+
+These places are maintained at https://github.com/owncloud/documentation/. 
+Another popular starting point for developer documentation is the `README.md` in GitHub.
 
 website
 -------

--- a/developer_manual/app/info.rst
+++ b/developer_manual/app/info.rst
@@ -27,6 +27,7 @@ The :file:`appinfo/info.xml` contains metadata about the app:
       <documentation>
           <user>https://doc.owncloud.org</user>
           <admin>https://doc.owncloud.org</admin>
+          <developer>https://doc.owncloud.org</developer>
       </documentation>
 
       <category>tool</category>
@@ -126,7 +127,7 @@ ownCloud allows to specify four kind of ``types``. Currently supported ``types``
 
 documentation
 -------------
-Link to 'developer', 'admin' and 'user' documentation
+**Required**: Link to 'developer', 'admin' and 'user' documentation
 
 Common places are: (where $name is the name of your app, e.g. $name=theapp)
 
@@ -142,15 +143,15 @@ Another popular starting point for developer documentation is the `README.md` in
 
 website
 -------
-Link to project web page
+**Required**: Link to project web page
 
 repository
 ----------
-Link to the version control repo
+**Required**: Link to the version control repo
 
 bugs
 ----
-Link to the bug tracker
+**Required**: Link to the bug tracker
 
 category
 --------


### PR DESCRIPTION
To support developers and contributers in finding the right places to place documentation I added these information here (source of the path definitions: https://github.com/owncloud/owncloud.org/blob/master/strings.php)