### PR TITLE
remove redundant CREATE USER command

### DIFF
--- a/admin_manual/configuration_database/linux_database_configuration.rst
+++ b/admin_manual/configuration_database/linux_database_configuration.rst
@@ -99,7 +99,6 @@ Then a **mysql>** or **MariaDB [root]>** prompt will appear. Now enter the follo
 
 ::
 
-  CREATE USER 'username'@'localhost' IDENTIFIED BY 'password';
   CREATE DATABASE IF NOT EXISTS owncloud;
   GRANT ALL PRIVILEGES ON owncloud.* TO 'username'@'localhost' IDENTIFIED BY 'password';
 


### PR DESCRIPTION
E.g. ```CREATE USER 'root'@'localhost' IDENTIFIED BY 'root';``` causes an error message, as the root user is a default user that always exists.
The CREATE USER command is redundant, as the final GRANT command creates all needed entries on the fly.