### PR TITLE
Fix shibboleth

### DIFF
--- a/admin_manual/enterprise_user_management/user_auth_shibboleth.rst
+++ b/admin_manual/enterprise_user_management/user_auth_shibboleth.rst
@@ -94,7 +94,7 @@ Further Shibboleth specific configuration as defined in
 	<Location ~ \
 	"/oc-shib/(status.php$\
 	|index.php/s/\
-	|public.php$\
+	|public.php\
 	|cron.php$\
 	|core/img/\
 	|index.php/apps/files_sharing/ajax/publicpreview.php$\


### PR DESCRIPTION
Public services are needed for Federation Sharing.
instead having `/public.php$` and `/public.php/webdav/` it is possible to have it open `/public.php`

@PVince81 @DeepDiver1975 Please review it. Thanks