### PR TITLE
index.php-less urls: docs doesn't apply for nginx

### DIFF
--- a/admin_manual/configuration_server/index_php_less_urls.rst
+++ b/admin_manual/configuration_server/index_php_less_urls.rst
@@ -4,7 +4,8 @@ Enable index.php-less URLs
 Since ownCloud 9.0.3 you need to explicitly configure and enable index.php-less URLs
 (e.g. https://example.com/apps/files/ instead of https://example.com/index.php/apps/files/).
 The following documentation provides the needed steps to configure this for the ``Apache``
-Web server.
+Web server. These steps are not necessary when using nginx as a web server because it is already
+enabled in the :doc:`../installation/nginx_owncloud_9x`.
 
 Prerequisites
 -------------


### PR DESCRIPTION
Fixes: #2557