### PR TITLE
Corrections / updated to HSTS documentation.

### DIFF
--- a/admin_manual/configuration_server/harden_server.rst
+++ b/admin_manual/configuration_server/harden_server.rst
@@ -94,13 +94,10 @@ Redirect all unencrypted traffic to HTTPS
 
 To redirect all HTTP traffic to HTTPS administrators are encouraged to issue a 
 permanent redirect using the 301 status code. When using Apache this can be 
-achieved by a setting such as the following in the Apache VirtualHosts 
-configuration::
+achieved by adding a setting such as the following in the Apache VirtualHosts 
+configuration containing the ``<VirtualHost *:80>`` entry::
 
-  <VirtualHost *:80>
-     ServerName cloud.owncloud.com
-     Redirect permanent / https://cloud.owncloud.com/
-  </VirtualHost>
+  Redirect permanent / https://example.com/
 
 .. _enable-hsts-label:
 
@@ -114,18 +111,29 @@ connection to the ownCloud instance using HTTP, and it attempts to prevent site
 visitors from bypassing invalid certificate warnings.
 
 This can be achieved by setting the following settings within the Apache 
-VirtualHost file::
+VirtualHost file containing the ``<VirtualHost *:443>`` entry::
 
- <VirtualHost *:443>
-   ServerName cloud.owncloud.com
-     <IfModule mod_headers.c>
-       Header always set Strict-Transport-Security "max-age=15552000; includeSubDomains; preload"
-     </IfModule>
-  </VirtualHost>
+  <IfModule mod_headers.c>
+    Header always set Strict-Transport-Security "max-age=15552000; includeSubDomains"
+  </IfModule>
+
+If you don't have access to your Apache configuration it is also possible to add this
+to the main ``.htaccess`` file shipped with ownCloud. Make sure you're adding it below
+the line::
+
+  #### DO NOT CHANGE ANYTHING ABOVE THIS LINE ####
   
-This example configuration will make all subdomains only accessible via HTTPS. If you have subdomains not accessible via HTTPS, remove ``includeSubdomains;``. 
+This example configuration will make all subdomains only accessible via HTTPS.
+If you have subdomains not accessible via HTTPS, remove ``includeSubDomains``.
 
-This requires the ``mod_headers`` extension in Apache.
+.. note:: This requires the ``mod_headers`` extension in Apache.
+
+When using nginx as a Web server an example is already included in the
+:doc:`../installation/nginx_owncloud_9x`::
+
+  #add_header Strict-Transport-Security "max-age=15552000; includeSubDomains";
+
+You need to remove the ``#`` and reload nginx to enable this change.
 
 Proper SSL configuration
 ************************

--- a/admin_manual/installation/nginx_owncloud_9x.rst
+++ b/admin_manual/installation/nginx_owncloud_9x.rst
@@ -38,7 +38,7 @@ your nginx installation.
   
       # Add headers to serve security related headers
       # Before enabling Strict-Transport-Security headers please read into this topic first.
-      # add_header Strict-Transport-Security "max-age=15768000; includeSubDomains; preload;";
+      #add_header Strict-Transport-Security "max-age=15552000; includeSubDomains";
       add_header X-Content-Type-Options nosniff;
       add_header X-Frame-Options "SAMEORIGIN";
       add_header X-XSS-Protection "1; mode=block";
@@ -78,7 +78,7 @@ your nginx installation.
   
       # Uncomment if your server is build with the ngx_pagespeed module
       # This module is currently not supported.
-      # pagespeed off;
+      #pagespeed off;
   
       error_page 403 /core/templates/403.php;
       error_page 404 /core/templates/404.php;
@@ -119,7 +119,7 @@ your nginx installation.
           add_header Cache-Control "public, max-age=7200";
           # Add headers to serve security related headers (It is intended to have those duplicated to the ones above)
           # Before enabling Strict-Transport-Security headers please read into this topic first.
-          # add_header Strict-Transport-Security "max-age=15768000; includeSubDomains; preload;";
+          #add_header Strict-Transport-Security "max-age=15552000; includeSubDomains";
           add_header X-Content-Type-Options nosniff;
           add_header X-Frame-Options "SAMEORIGIN";
           add_header X-XSS-Protection "1; mode=block";
@@ -166,7 +166,7 @@ your nginx installation.
   
       # Add headers to serve security related headers
       # Before enabling Strict-Transport-Security headers please read into this topic first.
-      # add_header Strict-Transport-Security "max-age=15768000; includeSubDomains; preload;";
+      #add_header Strict-Transport-Security "max-age=15552000; includeSubDomains";
       add_header X-Content-Type-Options nosniff;
       add_header X-Frame-Options "SAMEORIGIN";
       add_header X-XSS-Protection "1; mode=block";
@@ -185,8 +185,8 @@ your nginx installation.
   
       # The following 2 rules are only needed for the user_webfinger app.
       # Uncomment it if you're planning to use this app.
-      # rewrite ^/.well-known/host-meta /owncloud/public.php?service=host-meta last;
-      # rewrite ^/.well-known/host-meta.json /owncloud/public.php?service=host-meta-json last;
+      #rewrite ^/.well-known/host-meta /owncloud/public.php?service=host-meta last;
+      #rewrite ^/.well-known/host-meta.json /owncloud/public.php?service=host-meta-json last;
   
       location = /.well-known/carddav {
           return 301 $scheme://$host/owncloud/remote.php/dav;
@@ -208,7 +208,7 @@ your nginx installation.
   
           # Uncomment if your server is build with the ngx_pagespeed module
           # This module is currently not supported.
-          # pagespeed off;
+          #pagespeed off;
   
           error_page 403 /owncloud/core/templates/403.php;
           error_page 404 /owncloud/core/templates/404.php;
@@ -249,7 +249,7 @@ your nginx installation.
               add_header Cache-Control "public, max-age=7200";
               # Add headers to serve security related headers  (It is intended to have those duplicated to the ones above)
               # Before enabling Strict-Transport-Security headers please read into this topic first.
-              # add_header Strict-Transport-Security "max-age=15768000; includeSubDomains; preload;";
+              #add_header Strict-Transport-Security "max-age=15552000; includeSubDomains";
               add_header X-Content-Type-Options nosniff;
               add_header X-Frame-Options "SAMEORIGIN";
               add_header X-XSS-Protection "1; mode=block";


### PR DESCRIPTION
Some changes:

- Removed full vhost example as people managed to just copy and paste without understanding what they are doing: https://central.owncloud.org/t/enable-http-strict-transport-security-on-ubuntu/1989
- Removed ``preload`` from Apache and nginx examples. This is not described and needs admin actions to be effective. If people wants to enable it they should read into HSTS.
- Updated max-age from nginx with the ones from Apache (https://github.com/owncloud/documentation/issues/2347)
- Added description how to use HSTS within the ``.htaccess`` of oC