### PR TITLE
Add issue template to avoid support questions in here.

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,0 +1,5 @@
+<!--
+Please note this is the issue tracker for the ownCloud documentation published at https://doc.owncloud.org.
+
+This issue tracker is NOT the place to ask for support of ownCloud itself. Please use https://central.owncloud.org instead.
+-->


### PR DESCRIPTION
It seems that people still manage to ask support questions in here (e.g. https://github.com/owncloud/documentation/issues/2616 or https://github.com/owncloud/documentation/issues/2560)

This issue template hopefully avoids that.

For Pull Requests a similar template like seen in core could be created:

https://github.com/owncloud/core/blob/master/.github/PULL_REQUEST_TEMPLATE.md