### PR TITLE
Fix wrong description in external storage note.

### DIFF
--- a/admin_manual/configuration_files/external_storage_configuration_gui.rst
+++ b/admin_manual/configuration_files/external_storage_configuration_gui.rst
@@ -141,7 +141,10 @@ We recommend configuring the background job **Webcron** or
 to enable ownCloud to automatically detect files added to your external 
 storages. 
 
-.. Note:: You cannot share files on external storage mounts when you select the **Log-in credentials, save in session** authentication mechanism. However, there is a workaround, and that is to use Ajax cron mode. See :ref:`password_auth_workaround_label` for more information. 
+.. Note:: You cannot scan/detect changed files on external storage mounts when you select
+   the **Log-in credentials, save in session** authentication mechanism. However, there is
+   a workaround, and that is to use Ajax cron mode. See :ref:`password_auth_workaround_label`
+   for more information.
 
 ownCloud may not always be able to find out what has been
 changed remotely (files changed without going through ownCloud), especially


### PR DESCRIPTION
The text description doesn't match the issue description. Also make the overlong line a little bit shorter.