### PR TITLE
Fix wrong description in auth_mechanisms

### DIFF
--- a/admin_manual/configuration_files/external_storage/auth_mechanisms.rst
+++ b/admin_manual/configuration_files/external_storage/auth_mechanisms.rst
@@ -34,7 +34,9 @@ drawbacks are that sharing is disabled when this mechanism is in use, as
 ownCloud has no access to the storage credentials, and background file scanning 
 does not work.
 
-.. Note:: There is a workaround that allows sharing when using **Log-in credentials, save in session**, and that is using Ajax cron mode. (See :doc:`../../configuration_server/background_jobs_configuration`.)
+.. Note:: There is a workaround that allows background file scanning when using
+   **Log-in credentials, save in session**, and that is using Ajax cron mode.
+   (See :doc:`../../configuration_server/background_jobs_configuration`.)
 
 Public-key Mechanisms
 ---------------------


### PR DESCRIPTION
@PVince81 As discussed in https://github.com/owncloud/documentation/pull/2623#r79426617

https://github.com/owncloud/documentation/pull/2623 and https://github.com/owncloud/documentation/pull/2624 are already updated with that change.