### PR TITLE
Additional note to ajax cron and external storages scans

### DIFF
--- a/admin_manual/configuration_files/external_storage/auth_mechanisms.rst
+++ b/admin_manual/configuration_files/external_storage/auth_mechanisms.rst
@@ -36,7 +36,9 @@ does not work.
 
 .. Note:: There is a workaround that allows background file scanning when using
    **Log-in credentials, save in session**, and that is using Ajax cron mode.
-   (See :doc:`../../configuration_server/background_jobs_configuration`.)
+   (See :doc:`../../configuration_server/background_jobs_configuration`.). Be
+   aware that this Ajax cron mode need user actively browsing the WebGUI of
+   ownCloud or using the Sync Client.
 
 Public-key Mechanisms
 ---------------------


### PR DESCRIPTION
If people don't use the WebGUI or Sync Client that often the files won't be detected or with a high delay.