### PR TITLE
update 9.0 links to 9.1 links

### DIFF
--- a/admin_manual/installation/linux_installation.rst
+++ b/admin_manual/installation/linux_installation.rst
@@ -6,7 +6,7 @@ For production environments, we recommend the installation from the tar archive.
 This applies in particular to scenarios, where the Web server, storage and database are on separate machines. 
 In this constellation, all dependencies and requirements are managed by the package management 
 of your operating system, while the ownCloud code itself is maintained in a sequence of simple steps 
-as documented in our instructions for the :doc:`Manual Installation on Linux <source_installation.html>`_ and the :doc:`Manual ownCloud Upgrade <../maintenance/manual_upgrade.html>`_.
+as documented in our instructions for the :doc:`Manual Installation on Linux <source_installation>` and the :doc:`Manual ownCloud Upgrade <../maintenance/manual_upgrade>`.
 
 The package installation is for single-server setups only.
 

--- a/admin_manual/installation/linux_installation.rst
+++ b/admin_manual/installation/linux_installation.rst
@@ -6,7 +6,7 @@ For production environments, we recommend the installation from the tar archive.
 This applies in particular to scenarios, where the Web server, storage and database are on separate machines. 
 In this constellation, all dependencies and requirements are managed by the package management 
 of your operating system, while the ownCloud code itself is maintained in a sequence of simple steps 
-as documented in our instructions for the `Manual Installation on Linux <https://doc.owncloud.com/server/9.0/admin_manual/installation/source_installation.html>`_ and the `Manual ownCloud Upgrade <https://doc.owncloud.com/server/9.0/admin_manual/maintenance/manual_upgrade.html>`_.
+as documented in our instructions for the :doc:`Manual Installation on Linux <source_installation.html>`_ and the :doc:`Manual ownCloud Upgrade <../maintenance/manual_upgrade.html>`_.
 
 The package installation is for single-server setups only.
 
@@ -145,5 +145,5 @@ on how to correctly configure your environment if you have binary logging enable
 
 
 .. _Open Build Service: 
-   https://download.owncloud.org/download/repositories/9.0/owncloud/
+   https://download.owncloud.org/download/repositories/stable/owncloud/
    


### PR DESCRIPTION
Tried to replace 9.0-specific links with future-proof links that will point to the current version going forward. 