### PR TITLE
Move nginx update config block below static block

### DIFF
--- a/admin_manual/installation/nginx_examples.rst
+++ b/admin_manual/installation/nginx_examples.rst
@@ -138,11 +138,6 @@ your nginx installation.
           fastcgi_request_buffering off;
       }
   
-      location ~ ^/(?:updater|ocs-provider)(?:$|/) {
-          try_files $uri $uri/ =404;
-          index index.php;
-      }
-  
       # Adding the cache control header for js and css files
       # Make sure it is BELOW the PHP block
       location ~* \.(?:css|js)$ {
@@ -166,6 +161,12 @@ your nginx installation.
           # Optional: Don't log access to other assets
           access_log off;
       }
+  
+      location ~ ^/(?:updater|ocs-provider)(?:$|/) {
+          try_files $uri $uri/ =404;
+          index index.php;
+      }
+  
   }
 
 ownCloud in a subdir of nginx
@@ -268,11 +269,6 @@ your nginx installation.
               fastcgi_request_buffering off;
           }
   
-          location ~ ^/owncloud/(?:updater|ocs-provider)(?:$|/) {
-              try_files $uri $uri/ =404;
-              index index.php;
-          }
-  
           # Adding the cache control header for js and css files
           # Make sure it is BELOW the PHP block
           location ~* \.(?:css|js)$ {
@@ -296,6 +292,12 @@ your nginx installation.
               # Optional: Don't log access to other assets
               access_log off;
           }
+  
+          location ~ ^/owncloud/(?:updater|ocs-provider)(?:$|/) {
+              try_files $uri $uri/ =404;
+              index index.php;
+          }
+  
       }
   }
 


### PR DESCRIPTION
Follow-up of the suggestion of @josh4trunks in https://github.com/owncloud/documentation/pull/2551#issuecomment-236457783

For me it seems i don't even need the fix from https://github.com/owncloud/documentation/pull/2551 when moving the updater block below the static block .
