### PR TITLE
nginx config: Fix Windows WebDav client error 0x80070043

### DIFF
--- a/admin_manual/installation/nginx_examples.rst
+++ b/admin_manual/installation/nginx_examples.rst
@@ -118,12 +118,6 @@ your nginx installation.
           # Uncomment if you are going to use Windows WebDav client
           # Fixes Windows WebDav client error 0x80070043 "The network name cannot be found."
           #if ($http_user_agent = DavClnt) {
-          #    set $WinWebDav A;
-          #}
-          #if ($request_method = OPTIONS) {
-          #    set $WinWebDav "${WinWebDav}B";
-          #}
-          #if ($WinWebDav = AB) {
           #    return 401;
           #}
       }

--- a/admin_manual/installation/nginx_examples.rst
+++ b/admin_manual/installation/nginx_examples.rst
@@ -115,16 +115,17 @@ your nginx installation.
       error_page 404 /core/templates/404.php;
   
       location = / {
+          # Uncomment if you are going to use Windows WebDav client
           # Fixes Windows WebDav client error 0x80070043 "The network name cannot be found."
-          if ($http_user_agent = DavClnt) {
-              set $WinWebDav A;
-          }
-          if ($request_method = OPTIONS) {
-              set $WinWebDav "${WinWebDav}B";
-          }
-          if ($WinWebDav = AB) {
-              return 401;
-          }
+          #if ($http_user_agent = DavClnt) {
+          #    set $WinWebDav A;
+          #}
+          #if ($request_method = OPTIONS) {
+          #    set $WinWebDav "${WinWebDav}B";
+          #}
+          #if ($WinWebDav = AB) {
+          #    return 401;
+          #}
       }
   
       location / {

--- a/admin_manual/installation/nginx_examples.rst
+++ b/admin_manual/installation/nginx_examples.rst
@@ -114,10 +114,10 @@ your nginx installation.
       error_page 403 /core/templates/403.php;
       error_page 404 /core/templates/404.php;
   
-      # Fixes Windows WebDav client error 0x80070043 "The network name cannot be found."
       location = / {
+          # Fixes Windows WebDav client error 0x80070043 "The network name cannot be found."
           if ($request_method = OPTIONS) {
-              return 301 $scheme://$server_name/remote.php/webdav/;
+              return 401;
           }
       }
   

--- a/admin_manual/installation/nginx_examples.rst
+++ b/admin_manual/installation/nginx_examples.rst
@@ -114,6 +114,13 @@ your nginx installation.
       error_page 403 /core/templates/403.php;
       error_page 404 /core/templates/404.php;
   
+      # Fixes Windows WebDav client error 0x80070043 "The network name cannot be found."
+      location = / {
+          if ($request_method = OPTIONS) {
+              return 301 $scheme://$server_name/remote.php/webdav/;
+          }
+      }
+  
       location / {
           rewrite ^ /index.php$uri;
       }
@@ -243,6 +250,13 @@ your nginx installation.
   
           error_page 403 /owncloud/core/templates/403.php;
           error_page 404 /owncloud/core/templates/404.php;
+    
+          # Fixes Windows WebDav client error 0x80070043 "The network name cannot be found."
+          location = /owncloud/ {
+              if ($request_method = OPTIONS) {
+                  return 301 $scheme://$server_name/owncloud/remote.php/webdav/;
+              }
+          }
   
           location /owncloud {
               rewrite ^ /owncloud/index.php$uri;

--- a/admin_manual/installation/nginx_examples.rst
+++ b/admin_manual/installation/nginx_examples.rst
@@ -116,7 +116,13 @@ your nginx installation.
   
       location = / {
           # Fixes Windows WebDav client error 0x80070043 "The network name cannot be found."
+          if ($http_user_agent = DavClnt) {
+              set $WinWebDav A;
+          }
           if ($request_method = OPTIONS) {
+              set $WinWebDav "${WinWebDav}B";
+          }
+          if ($WinWebDav = AB) {
               return 401;
           }
       }

--- a/admin_manual/installation/nginx_examples.rst
+++ b/admin_manual/installation/nginx_examples.rst
@@ -250,13 +250,6 @@ your nginx installation.
   
           error_page 403 /owncloud/core/templates/403.php;
           error_page 404 /owncloud/core/templates/404.php;
-    
-          # Fixes Windows WebDav client error 0x80070043 "The network name cannot be found."
-          location = /owncloud/ {
-              if ($request_method = OPTIONS) {
-                  return 301 $scheme://$server_name/owncloud/remote.php/webdav/;
-              }
-          }
   
           location /owncloud {
               rewrite ^ /owncloud/index.php$uri;


### PR DESCRIPTION
Windows native client gives error 0x80070043 "The network name cannot be found." when you creating network drive for ownCloud.
After some researches I figured out problem:
WebDav client sends `OPTIONS / HTTP/1.1` request even if target address was `/remote.php/webdav/`.
So obvious solution is to send 301 redirect to `/remote.php/webdav/` for all `OPTIONS` requests to `/`.

Network dump before fix:

```
> OPTIONS / HTTP/1.1
< HTTP/1.1 302 Moved Temporarily
  Location: https://owncloud.example.com/login
> OPTIONS /login HTTP/1.1
< HTTP/1.1 405 Method Not Allowed
```

Network dump after fix:

```
> OPTIONS / HTTP/1.1
< HTTP/1.1 301 Moved Permanently
  Location: https://owncloud.example.com/remote.php/webdav/
> OPTIONS /remote.php/webdav/ HTTP/1.1
< HTTP/1.1 401 Unauthorized
> OPTIONS /remote.php/webdav/ HTTP/1.1
  Authorization: Basic BasicAuthTokenHere=
< HTTP/1.1 200 OK
```

Fix:

```
location = / {
    if ($request_method = OPTIONS) {
        return 301 $scheme://$server_name/remote.php/webdav/;
    }
}
```
