### PR TITLE
oC9.2+: Requires to use at least desktop client version 2.0 by default.

### DIFF
--- a/admin_manual/release_notes.rst
+++ b/admin_manual/release_notes.rst
@@ -7,7 +7,7 @@ Changes in 9.2
 
 * Supported PHP versions are 5.6+ and 7.0+. 
 * The upgrade migration test has been removed; see :ref:`migration_test_label`.
-
+* Requires to use at least desktop client version 2.0 by default.
 
 Changes in 9.1
 --------------

--- a/user_manual/whats_new.rst
+++ b/user_manual/whats_new.rst
@@ -3,5 +3,6 @@ What's New for Users in ownCloud |version|
 ==========================================
 
 * Option to hide or expose hidden files in the Web GUI
+* Requires to use at least desktop client version 2.0 by default.
 
 


### PR DESCRIPTION
Ref: https://github.com/owncloud/core/pull/26441

9.2+