### PR TITLE
refined SELinux Settings for ownCloud 9.1

### DIFF
--- a/admin_manual/installation/selinux_configuration.rst
+++ b/admin_manual/installation/selinux_configuration.rst
@@ -12,22 +12,28 @@ The following settings should work for most SELinux systems that use the
 default distro profiles. Run these commands as root, and remember to adjust the filepaths 
 in these examples for your installation::
 
- semanage fcontext -a -t httpd_sys_rw_content_t '/var/www/html/owncloud/data'
- restorecon '/var/www/html/owncloud/data'
- semanage fcontext -a -t httpd_sys_rw_content_t '/var/www/html/owncloud/config'
- restorecon '/var/www/html/owncloud/config'
- semanage fcontext -a -t httpd_sys_rw_content_t '/var/www/html/owncloud/apps'
- restorecon '/var/www/html/owncloud/apps'
+ semanage fcontext -a -t httpd_sys_rw_content_t '/var/www/html/owncloud/data(/.*)?'
+ semanage fcontext -a -t httpd_sys_rw_content_t '/var/www/html/owncloud/config(/.*)?'
+ semanage fcontext -a -t httpd_sys_rw_content_t '/var/www/html/owncloud/apps(/.*)?'
+ semanage fcontext -a -t httpd_sys_rw_content_t '/var/www/html/owncloud/assets(/.*)?'
+ semanage fcontext -a -t httpd_sys_rw_content_t '/var/www/html/owncloud/.htaccess'
+ semanage fcontext -a -t httpd_sys_rw_content_t '/var/www/html/owncloud/.user.ini'
+ 
+ restorecon -Rv '/var/www/html/owncloud/'
  
 If you uninstall ownCloud you need to remove the ownCloud directory labels. To do 
 this execute the following commands as root after uninstalling ownCloud::
 
- semanage fcontext -d -t httpd_sys_rw_content_t '/var/www/html/owncloud/data'
- restorecon '/var/www/html/owncloud/data'
- semanage fcontext -d -t httpd_sys_rw_content_t '/var/www/html/owncloud/config'
- restorecon '/var/www/html/owncloud/config'
- semanage fcontext -d -t httpd_sys_rw_content_t '/var/www/html/owncloud/apps'
- restorecon '/var/www/html/owncloud/apps'
+ semanage fcontext -d '/var/www/html/owncloud/data(/.*)?'
+ semanage fcontext -d '/var/www/html/owncloud/config(/.*)?'
+ semanage fcontext -d '/var/www/html/owncloud/apps(/.*)?'
+ semanage fcontext -d '/var/www/html/owncloud/assets(/.*)?'
+ semanage fcontext -d '/var/www/html/owncloud/.htaccess'
+ semanage fcontext -d '/var/www/html/owncloud/.user.ini'
+ 
+ restorecon -Rv '/var/www/html/owncloud/'
+ 
+Note: The assets folder is only required if JavaScript and CSS Asset Management is enabled. ('asset-pipeline.enabled' => true, in config.php)
 
 If you have customized SELinux policies and these examples do not work, you must give the 
 HTTP server write access to these directories::
@@ -35,6 +41,14 @@ HTTP server write access to these directories::
  /var/www/html/owncloud/data
  /var/www/html/owncloud/config
  /var/www/html/owncloud/apps
+ /var/www/html/owncloud/assets
+ 
+Disallow write access to the whole web directory
+------------------------------------------------
+
+For security reasons it's suggested to disable write access to all folders in /var/www/ (default):
+
+ setsebool -P  httpd_unified  off
 
 Allow access to a remote database
 ---------------------------------
@@ -57,6 +71,13 @@ ownCloud requires access to remote networks for functions such as Server-to-Serv
 the app store. To allow this access use the following setting::
 
  setsebool -P httpd_can_network_connect on
+ 
+Allow access to network memcache
+--------------------------------
+
+This setting is not required if httpd_can_network_connect is already on
+
+ setsebool -P httpd_can_network_memcache on
 
 Allow access to SMTP/sendmail
 -----------------------------
@@ -72,6 +93,20 @@ Allow access to CIFS/SMB
 If you have placed your datadir on a CIFS/SMB share use the following setting::
 
  setsebool -P httpd_use_cifs on
+ 
+Allow access to FuseFS
+----------------------
+
+If your owncloud data folder resides on a Fuse Filesystem (e.g. EncFS etc), this setting is required as well:
+
+ setsebool -P httpd_use_fusefs on
+ 
+Allow access to GPG for Rainloop
+--------------------------------
+
+If you use a the rainloop webmail client app which supports GPG/PGP, you might need this:
+
+ setsebool -P httpd_use_gpg on
 
 Troubleshooting
 ---------------


### PR DESCRIPTION
I just started migration to SELinux on CentOS 7.2 and noticed that some more files were requesting write access with ownCloud 9.1.1 (9.1.1.3 stable). (notably: the assets folder, .user.ini and .htaccess).

I also removed the duplicate restorecon lines because running it recursively at the end on the whole owncloud folder makes more sense than running it after each small change.

I assume this guide is considering a working SELinux environment with working PHP etc. Else I might have to add some more sebooleans :) (httpd_builtin_scripting, httpd_enable_cgi)