### PR TITLE
Fix bash error that will cause script to die

### DIFF
--- a/bin/unix/install-dependencies/opensuse.sh
+++ b/bin/unix/install-dependencies/opensuse.sh
@@ -14,12 +14,10 @@ set -e
 
 function install_dependencies()
 {
-    # first check if the repository's already been added
-    zypper lr | grep --silent devel_languages_python
-
-    if [ "$?" -eq 1 ]; then
+    # first check if the repository's already been added and add it if not
+    if ! zypper lr | grep --silent devel_languages_python; then
         echo "Adding the devel:languages:python repository to the available repository list"
-        sudo zypper addrepo --refresh http://download.opensuse.org/repositories/devel:languages:python/openSUSE_Leap_42.1/devel:languages:python.repo;
+        sudo zypper addrepo --refresh http://download.opensuse.org/repositories/devel:languages:python/openSUSE_Leap_42.1/devel:languages:python.repo
     fi;
 
     echo "Installing required platform dependencies..."


### PR DESCRIPTION
Using `set -e` means that  every line in the script is expected to succeed in its own right. Running something just to try it and testing the return code later won't work in this mode. If you want to branch based on the return code of a command (or in this case pipeline) you need to make it part of the if statement so bash has somewhere to go while still succeeding after every command structure.