### PR TITLE
Update GETTING_STARTED.rst

### DIFF
--- a/GETTING_STARTED.rst
+++ b/GETTING_STARTED.rst
@@ -46,7 +46,8 @@ Required Software
 #. Git
 #. Sphinx Documentation Generator and Python
 #. Python Image Library (PIL)
-#. Sphinx PHPDomain
+#. Sphinx PHPDomain (python-sphinxcontrib.phpdomain)
+#. sphinx-build
 #. rst2pdf
 #. LaTex. Install the whole works, which is several hundred megabytes.
 #. VPN client, such as OpenVPN


### PR DESCRIPTION
added sphinx-build to the list of required software. Once bitten, twice documented.
Added the exact debian/ubuntu name of python-sphinxcontrib.phpdomain