### PR TITLE
Add a "How To Create An Issue" section to the README

### DIFF
--- a/CREATING_ISSUES.rst
+++ b/CREATING_ISSUES.rst
@@ -1,6 +1,6 @@
-======================
-How To Create An Issue
-======================
+===============================
+How To Get Something Documented
+===============================
 
 If you want to create an issue in the repository, please follow this guide, to
 ensure that your ticket has the greatest likelihood of being actioned.

--- a/CREATING_ISSUES.rst
+++ b/CREATING_ISSUES.rst
@@ -1,0 +1,72 @@
+======================
+How To Create An Issue
+======================
+
+If you want to create an issue in the repository, please follow this guide, to
+ensure that your ticket has the greatest likelihood of being actioned.
+
+1. Add a Good Title and Body
+----------------------------
+
+When creating a good title and body, bear the following points in mind:
+
+- Be concise and descriptive
+- Write in the active tense
+- Start the title with a verb
+- Use bullets and images where appropriate
+
+Let’s expand on those four points. Ensure that the issue has a descriptive, yet
+concise, title. Make sure that the title uses the active tense and, ideally,
+starts with a verb and is no longer than 80 chars. 
+
+The reason for this is that, as with search results, a title is the first (and
+perhaps only) thing that people will read. So, it has to quickly convey what
+the issue is for. 
+
+Active tense requires less effort to read, and often contains fewer words. So
+it’s far more effective than the passive tense. What’s more, by starting with
+a verb, it’s even clearer as to what’s being asked.
+
+For example, instead of:
+
+ Procedure for publishing a new branded iOS app
+
+Rewrite it as this, instead:
+
+ Update the procedure for publishing a new branded iOS app
+
+Ensure that it has a descriptive, yet concise, body. Please, write as long as
+you need to, but no longer. You should aim to provide as much information as
+you need, but try not to waffle. The body supplements the title, expanding on
+what the title cannot say. However, it’s not War and Peace. 
+
+When formatting the body, bullet points are likely easier and quicker to read
+through than large paragraphs. But whichever conveys the information the best
+is the one to choose. So, there’s no hard and fast rules.
+
+If images are applicable, please use them. Sometimes, borrowing the old cliché,
+*"a picture is worth a thousand words"*. If so, then use an image and save time and
+effort.  
+
+2. Set a Milestone
+------------------
+
+Currently, there are only two milestones: **10.0** (the next release) and
+**"Documentation Backlog"**. Normally, you should put the issue straight in
+**"Documentation Backlog"**. But, if it’s urgent, add it to **10.0**.
+
+3. Add Applicable Labels
+------------------------
+
+The next thing to do is to categorise the ticket with one, or more, labels.
+These are effectively categories, which make the ticket easier to search and
+filter on. If an applicable label isn’t available, please choose the next best
+one, or create a new label (following the existing style) and add it to the
+issue.
+
+4. Assign a User or Notify a Group
+----------------------------------
+
+Finally, depending on the nature of the issue, either assign one or more users
+to the Issue, or mention the @owncloud/doc group in the issue’s description or
+comment. 

--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,0 +1,13 @@
+Make sure that you’ve done the following before submitting your issue - _thank you!_
+
+- [ ] Provided a concise and descriptive title
+- [ ] Provided a concise and descriptive body
+- [ ] Set a milestone
+- [ ] Added applicable labels (or created them if no applicable ones exist)
+- [ ] Assigned an applicable user
+- [ ] Added a reviewer or notified @owncloud/doc
+
+### Also
+
+- You can find the ownCloud documentation at https://doc.owncloud.org
+- This issue tracker is **NOT** the place to ask for support of ownCloud itself. Please use https://central.owncloud.org instead

--- a/README.rst
+++ b/README.rst
@@ -32,6 +32,25 @@ Please work in the appropriate branch.
 .. note:: ``configuration_server/config_sample_php_parameters.rst`` is auto-generated from the core
    config.sample.php file; changes to this file must be made in core `<https://github.com/owncloud/core/tree/master/config>`_
 
+How To Create An Issue
+----------------------
+
+For detailed information on how to create an issue in the documentation
+repository, please refer to `the "How To Create An Issue" guide
+<CREATING_ISSUES.rst>`_. 
+
+This process overrides **all** previous practices, and aims to formalise and
+simplify the process of creating requests for change within the ownCloud
+documentation. 
+
+Issues should no longer be created in any of the other ownCloud repositories.
+Doing so makes it too difficult and time-intensive to stay on top of all the
+requests for change relating to documentation. 
+
+What’s more, issues created in other repositories may be closed without being
+actioned (though more than likely they’ll be gently requested to be recreated
+within this repository).
+
 Style Guide
 -----------
 


### PR DESCRIPTION
This PR:

- Tries to make it explicitly clear how to create issues in the documentation repository, listing the key steps involved.