### PR TITLE
Document how to manually move a data directory

### DIFF
--- a/admin_manual/maintenance/index.rst
+++ b/admin_manual/maintenance/index.rst
@@ -13,3 +13,4 @@ Maintenance
    manual_upgrade
    restore
    migrating
+   manually-moving-data-folders

--- a/admin_manual/maintenance/manually-moving-data-folders.rst
+++ b/admin_manual/maintenance/manually-moving-data-folders.rst
@@ -29,18 +29,17 @@ To save time, here's the commands which you can copy and use::
    If you're on Centos, try `service httpd stop` and `service httpd start`.
    If you're on Debian/Ubuntu try `sudo service apache2 stop` and `sudo service apache2 start`
 
-Updating The Database Manually
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Fix Hardcoded Database Path Variables
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 If you want to manually change the location of the data folder in the database,
 run the SQL below:
 
 .. code-block::
    
-  UPDATE oc_storages SET id='local::/var/www/owncloud/data' WHERE id='local::/mnt/owncloud'
+  UPDATE oc_storages SET id='local::/var/www/owncloud/data' 
+    WHERE id='local::/mnt/owncloud'
 
-Hardcoded Database Path Variables 
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 The other area to check is the `oc_jobs` table. The logrotate process may have
 hard-coded a non-standard (or old) value for the data path. To check it, run the
 SQL below and see if any results are returned:
@@ -56,6 +55,8 @@ If any are, run the SQL below to update them, changing the value as appropriate.
   UPDATE oc_jobs SET argument = '/your/new/data/path' 
     WHERE id = <id of the incorrect record>;
 
+Fix Application Settings 
+~~~~~~~~~~~~~~~~~~~~~~~~
 
 One thing worth noting is that individual apps may reference the data directory
 separate from the core system configuration. If so, then you will need to find

--- a/admin_manual/maintenance/manually-moving-data-folders.rst
+++ b/admin_manual/maintenance/manually-moving-data-folders.rst
@@ -1,0 +1,75 @@
+=====================================
+How To Manually Move a Data Directory
+=====================================
+
+If you need to move your ownCloud data directory from its current location to
+somewhere else, here is a manual process that you can take to make it happen.
+
+.. NOTE:: 
+   This example assumes that:
+
+   - The current folder is: `/var/www/owncloud/data`
+   - The new folder is: `/mnt/owncloud`
+   - You're using Apache as your webserver
+
+1. Stop Apache
+2. Use rsync to sync the files from the current folder to the new one the folders -> 
+3. Create a symbolic link from the new directory to the old one 
+4. Double-check `the directory permissions`_ on the new directory 
+5. Restart Apache
+
+To save time, here's the commands which you can copy and use::
+
+  apachectl -k stop 
+  rsync -avz /var/www/owncloud/data /mnt/owncloud
+  ln -s /mnt/owncloud /www/owncloud/data
+  apachectl -k graceful 
+
+.. NOTE:: 
+   If you're on Centos, try `service httpd stop` and `service httpd start`.
+   If you're on Debian/Ubuntu try `sudo service apache2 stop` and `sudo service apache2 start`
+
+Updating The Database Manually
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If you want to manually change the location of the data folder in the database,
+run the SQL below:
+
+.. code-block::
+   
+  UPDATE oc_storages SET id='local::/var/www/owncloud/data' WHERE id='local::/mnt/owncloud'
+
+Hardcoded Database Path Variables 
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+One thing worth noting is that individual apps may reference the data directory
+separate from the core system configuration. If so, then you will need to find
+which applications do this, and change them as needed. 
+
+For example, if you listed the application configuration by running `occ
+config:list`, then you might see output similar to that below:
+
+.. code-block::
+
+  {
+      "apps": {
+          "fictitious": {
+              "enabled": "yes",
+              "installed_version": "2.3.2",
+              "types": "filesystem",
+              "datadir": "var/www/owncloud/data"
+          }
+      }
+  }
+
+Here, the "fictitious" application references the data directory as being set to
+`var/www/owncloud/data`. So you would have to change the value by using the
+`config:app:set` option. Here's an example of how you would update the setting:
+
+.. code-block::
+
+  occ config:app:set --value /mnt/owncloud fictitious datadir
+
+.. Links
+
+.. _the directory permissions: https://doc.owncloud.org/server/9.1/admin_manual/installation/installation_wizard.html#strong-perms-label

--- a/admin_manual/maintenance/manually-moving-data-folders.rst
+++ b/admin_manual/maintenance/manually-moving-data-folders.rst
@@ -41,6 +41,21 @@ run the SQL below:
 
 Hardcoded Database Path Variables 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The other area to check is the `oc_jobs` table. The logrotate process may have
+hard-coded a non-standard (or old) value for the data path. To check it, run the
+SQL below and see if any results are returned:
+
+.. code-block::
+
+  SELECT * FROM oc_jobs WHERE class = 'OC\Log\Rotate';
+
+If any are, run the SQL below to update them, changing the value as appropriate.
+
+.. code-block::
+
+  UPDATE oc_jobs SET argument = '/your/new/data/path' 
+    WHERE id = <id of the incorrect record>;
+
 
 One thing worth noting is that individual apps may reference the data directory
 separate from the core system configuration. If so, then you will need to find

--- a/admin_manual/maintenance/manually-moving-data-folders.rst
+++ b/admin_manual/maintenance/manually-moving-data-folders.rst
@@ -13,7 +13,7 @@ somewhere else, here is a manual process that you can take to make it happen.
    - You're using Apache as your webserver
 
 1. Stop Apache
-2. Use rsync to sync the files from the current folder to the new one the folders -> 
+2. Use rsync to sync the files from the current folder to the new one 
 3. Create a symbolic link from the new directory to the old one 
 4. Double-check `the directory permissions`_ on the new directory 
 5. Restart Apache

--- a/admin_manual/maintenance/manually-moving-data-folders.rst
+++ b/admin_manual/maintenance/manually-moving-data-folders.rst
@@ -35,7 +35,7 @@ Fix Hardcoded Database Path Variables
 If you want to manually change the location of the data folder in the database,
 run the SQL below:
 
-.. code-block::
+.. code-block:: sql
    
   UPDATE oc_storages SET id='local::/var/www/owncloud/data' 
     WHERE id='local::/mnt/owncloud'
@@ -44,13 +44,13 @@ The other area to check is the `oc_jobs` table. The logrotate process may have
 hard-coded a non-standard (or old) value for the data path. To check it, run the
 SQL below and see if any results are returned:
 
-.. code-block::
+.. code-block:: sql
 
   SELECT * FROM oc_jobs WHERE class = 'OC\Log\Rotate';
 
 If any are, run the SQL below to update them, changing the value as appropriate.
 
-.. code-block::
+.. code-block:: sql
 
   UPDATE oc_jobs SET argument = '/your/new/data/path' 
     WHERE id = <id of the incorrect record>;
@@ -65,7 +65,7 @@ which applications do this, and change them as needed.
 For example, if you listed the application configuration by running `occ
 config:list`, then you might see output similar to that below:
 
-.. code-block::
+.. code-block:: json
 
   {
       "apps": {
@@ -82,7 +82,7 @@ Here, the "fictitious" application references the data directory as being set to
 `var/www/owncloud/data`. So you would have to change the value by using the
 `config:app:set` option. Here's an example of how you would update the setting:
 
-.. code-block::
+.. code-block:: console
 
   occ config:app:set --value /mnt/owncloud fictitious datadir
 


### PR DESCRIPTION
Requested in #2303, this PR:

- Adds a section to the admin manual that documents how to manually move a data directory from one location to another
- Covers manually updating the database 
- Shows how to update application configuration settings