### PR TITLE
Document the Makefile Targets Available In Core

### DIFF
--- a/developer_manual/general/devenv.rst
+++ b/developer_manual/general/devenv.rst
@@ -87,6 +87,33 @@ or::
 After the clone Open http://localhost/core (or the corresponding URL) in your web browser to set up your instance.
 
 Enabling debug mode
+Command-Line Automation
+-----------------------
+
+If you’re keen to save as much time and effort as possible then take advantage
+of the automation available in the most recent version of ownCloud, via `Make`_. 
+
+Below are the available commands, including the target name and a short
+description of what each of them does.
+
+================== ============================================================
+Target             Description
+================== ============================================================
+make               Pulls in both Composer and Bower dependencies
+make clean         Cleans up dependencies. This is useful for starting over or 
+                   when switching to older branches
+make dist          Builds a minimal owncloud-core tarball with only core apps
+                   in `build/dist/core`, stripped of unwanted files
+make docs          Builds the JavaScript documentation using `JSDoc`_
+make test          Runs all of the test targets 
+make test-external Runs one of the external storage tests, and is configurable 
+                   through make variables
+make test-js       Runs the Javascript unit tests, replacing `./autotest-js.sh`
+make test-php      Runs the PHPUnit tests with SQLite as the datasource. This 
+                   replaces `./autotest.sh sqlite`  and is configurable through 
+                   make variables
+================== ============================================================
+
 -------------------
 .. _debugmode:
 
@@ -103,3 +130,7 @@ To disable JavaScript and CSS caching debugging has to be enabled by setting ``d
 .. _GitHub: https://github.com/owncloud
 .. _GitHub Help Page: https://help.github.com/
 
+.. Links
+
+.. _Make: https://www.gnu.org/software/make/
+.. _JSDoc: http://usejsdoc.org

--- a/developer_manual/general/devenv.rst
+++ b/developer_manual/general/devenv.rst
@@ -8,21 +8,21 @@ Development Environment
 
 Please follow the steps on this page to set up your development environment.
 
-Basic tools
+Basic Tools
 ===========
 
 To be able to develop with ownCloud and also run unit tests, you will need to install `Node.js <https://nodejs.org>`_.
 
 Other required tools will be automatically installed by composer.
 
-Set up Web server and database
+Set Up Web Server And Database
 ==============================
 
 First `set up your Web server and database <https://doc.owncloud.org/server/9.0/admin_manual/installation/index.html>`_ (**Section**: Manual Installation - Prerequisites).
 
 .. TODO ON RELEASE: Update version number above on release
 
-Get the source
+Get The Source
 ==============
 
 There are two ways to obtain ownCloud sources: 
@@ -33,7 +33,7 @@ There are two ways to obtain ownCloud sources:
 
 To check out the source from `GitHub`_ you will need to install git (see `Setting up git <https://help.github.com/articles/set-up-git>`_ from the GitHub help)
 
-Gather information about server setup
+Gather Information About Server Setup
 -------------------------------------
 
 To get started the basic git repositories need to cloned into the Web server's directory. Depending on the distribution this will either be
@@ -50,7 +50,7 @@ Then identify the user and group the Web server is running as and the Apache use
 * **apache**
 * **wwwrun**
 
-Check out the code
+Check Out The Code
 ------------------
 
 The following commands are using **/var/www** as the Web server's directory and **www-data** as user name and group.
@@ -86,7 +86,6 @@ or::
 
 After the clone Open http://localhost/core (or the corresponding URL) in your web browser to set up your instance.
 
-Enabling debug mode
 Command-Line Automation
 -----------------------
 
@@ -114,6 +113,7 @@ make test-php      Runs the PHPUnit tests with SQLite as the datasource. This
                    make variables
 ================== ============================================================
 
+Enabling Debug Mode
 -------------------
 .. _debugmode:
 


### PR DESCRIPTION
This PR:

- Adds the documentation on the Makefile targets supplied in #2604 to the developer manual

I added one or two more, after browsing the Makefile as part of research for this PR.