### PR TITLE
Update Developer Background Jobs Documentation 

### DIFF
--- a/developer_manual/app/backgroundjobs.rst
+++ b/developer_manual/app/backgroundjobs.rst
@@ -4,36 +4,58 @@ Background Jobs (Cron)
 
 .. sectionauthor:: Bernhard Posselt <dev@bernhard-posselt.com>
 
-Background/cron jobs are usually registered in the :file:`appinfo/app.php` by using the **addRegularTask** method, the class and the method to run:
+ownCloud supports background job functionality (otherwise known as `Cron jobs`_).
+To create them requires two steps to be completed:
 
-.. code-block:: php
+- Create a job class
+- Register the class with ownCloud
 
-    <?php
-    \OCP\Backgroundjob::addRegularTask('\OCA\MyApp\Cron\SomeTask', 'run');
+Create a job class
+==================
 
-The class for the above example would live in :file:`cron/sometask.php`. Try to keep the method as small as possible because its hard to test static methods. Simply reuse the app container and execute a service that was registered in it.
+The first step is to create a job class, which will provide the job functionality. 
+For this example, we will call it: :file:`cron/sometask.php`. 
+The class only needs to define one, static, method called ``run``. 
+In this example, we’re retrieving a service from the container, and in turn
+calling its ``run`` method.
 
-.. code-block:: php
+.. NOTE:: 
+   Try to keep the method as small as possible, because its hard to test static
+   methods.
 
-    <?php
-    namespace OCA\MyApp\Cron;
+.. literalinclude:: ../examples/cron/SomeTask.php
+   :language: php
+   :linenos:
 
-    use \OCA\MyApp\AppInfo\Application;
+Register the class with ownCloud
+================================
 
-    class SomeTask {
+Next, you need to register the job as a background job. 
+This is done in :file:`appinfo/info.xml` by adding a job element, containing the
+name of the job class, to the ``background-jobs`` element. 
+The example below shows how to add the ``SomeTask`` class, which we just
+created, as a background job.:
 
-        public static function run() {
-            $app = new Application();
-            $container = $app->getContainer();
-            $container->query('SomeService')->run();
-        }
+.. code-block:: xml
+   
+    <background-jobs>
+        <job>\OCA\MyApp\Cron\SomeTask</job>
+    </background-jobs>
 
-    }
+Is The Cron Service Running?
+============================
 
-Dont forget to configure the cron service on the server by executing::
+Don’t forget to add the ownCloud Cron process in the web server’s `crontab`_. To do this, first open the web server’s crontab for editing by running::
 
+    # In this example ``http`` is the web server user
     sudo crontab -u http -e
 
-where **http** is your Web server user, and add::
+Then, add the ownCloud Cron process to the crontab, for example, like so::
 
     */15  *  *  *  * php -f /srv/http/owncloud/cron.php
+    
+
+.. Links
+   
+.. _Cron jobs: https://en.wikipedia.org/wiki/Cron
+.. _crontab: http://www.adminschoice.com/crontab-quick-reference

--- a/developer_manual/app/backgroundjobs.rst
+++ b/developer_manual/app/backgroundjobs.rst
@@ -14,7 +14,7 @@ Create a job class
 ==================
 
 The first step is to create a job class, which will provide the job functionality. 
-For this example, we will call it: :file:`cron/sometask.php`. 
+For this example, we will call it: :file:`lib/Cron/SomeTask.php`. 
 The class only needs to define one, static, method called ``run``. 
 In this example, we’re retrieving a service from the container, and in turn
 calling its ``run`` method.
@@ -42,10 +42,24 @@ created, as a background job.:
         <job>\OCA\MyApp\Cron\SomeTask</job>
     </background-jobs>
 
+Testing
+=======
+
+To test the job classes, you can run Cron manually, as in the example below:
+
+    sudo -u http php cron.php
+
+After doing so, you will need to reset the job to allow it to be run, manually, again. 
+To do this, go to the database and run the following SQL query:
+
+.. code-block: sql
+
+    UPDATE oc_jobs SET last_run=0,last_checked=0,reserved_at=0;
+
 Is The Cron Service Running?
 ============================
 
-Don’t forget to add the ownCloud Cron process in the web server’s `crontab`_. To do this, first open the web server’s crontab for editing by running::
+Finally, don’t forget to add the ownCloud Cron process in the web server’s `crontab`_. To do this, first open the web server’s crontab for editing by running::
 
     # In this example ``http`` is the web server user
     sudo crontab -u http -e

--- a/developer_manual/examples/cron/SomeTask.php
+++ b/developer_manual/examples/cron/SomeTask.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace OCA\MyApp\Cron;
+
+use \OCA\MyApp\AppInfo\Application;
+
+class SomeTask
+{
+    public static function run()
+    {
+        (new Application())
+            ->getContainer()
+            ->query('SomeService')
+            ->run();
+    }
+}

--- a/developer_manual/examples/cron/SomeTask.php
+++ b/developer_manual/examples/cron/SomeTask.php
@@ -4,7 +4,7 @@ namespace OCA\MyApp\Cron;
 
 use \OCA\MyApp\AppInfo\Application;
 
-class SomeTask
+class SomeTask extends OC\BackgroundJob\TimedJob
 {
     public static function run()
     {

--- a/developer_manual/examples/cron/SomeTask.php
+++ b/developer_manual/examples/cron/SomeTask.php
@@ -4,10 +4,9 @@ namespace OCA\MyApp\Cron;
 
 use \OCA\MyApp\AppInfo\Application;
 
-class SomeTask extends OC\BackgroundJob\TimedJob
-{
-    public static function run()
-    {
+class SomeTask extends OC\BackgroundJob\TimedJob {
+    
+    protected function run($argument) {
         (new Application())
             ->getContainer()
             ->query('SomeService')


### PR DESCRIPTION
This PR:

- Updates how to register background job classes with ownCloud
- Updates the remaining content to be easier and quicker to follow