### PR TITLE
Added a hint regarding config.php

### DIFF
--- a/admin_manual/installation/nginx_examples.rst
+++ b/admin_manual/installation/nginx_examples.rst
@@ -172,7 +172,7 @@ ownCloud in a subdir of nginx
 =============================
 
 The following config should be used when ownCloud is not in your webroot but placed under a different contextroot of 
-your nginx installation such as /owncloud or /cloud. The following configuration assumes it is placed under ``/owncloud``.
+your nginx installation such as /owncloud or /cloud. The following configuration assumes it is placed under ``/owncloud`` and that you have ``'overwritewebroot' => '/owncloud',`` set in your ``config/config.php``.
 
 ::
 


### PR DESCRIPTION
We forgot to explicitly mention that in order to serve owncloud from a subdirectory, the according `config.php` parameter `overwritewebroot` has to match the contextpath/ webroot used in the nginx configuration.