### PR TITLE
Add admonition that sharing to federated groups is not supported

### DIFF
--- a/user_manual/files/federated_cloud_sharing.rst
+++ b/user_manual/files/federated_cloud_sharing.rst
@@ -7,7 +7,7 @@ creating your own cloud of ownClouds. You can create direct share links with
 users on other ownCloud servers.
 
 .. important:: 
-   Sharing to federated groups is not supported.
+   Sharing to groups from federated ownCloud instances is not supported.
 
 Creating a New Federation Share
 -------------------------------

--- a/user_manual/files/federated_cloud_sharing.rst
+++ b/user_manual/files/federated_cloud_sharing.rst
@@ -6,6 +6,9 @@ Federation Sharing allows you to mount file shares from remote ownCloud servers,
 creating your own cloud of ownClouds. You can create direct share links with 
 users on other ownCloud servers.
 
+.. important:: 
+   Sharing to federated groups is not supported.
+
 Creating a New Federation Share
 -------------------------------
 


### PR DESCRIPTION
This PR:

- Adds an important admonition to the documentation that sharing to federated groups is not supported

### References

owncloud/core/issues/16507