### PR TITLE
Add reverse proxy configuration in example

### DIFF
--- a/admin_manual/configuration_server/reverse_proxy_configuration.rst
+++ b/admin_manual/configuration_server/reverse_proxy_configuration.rst
@@ -71,6 +71,13 @@ you can set the following parameters inside the :file:`config/config.php`.
     "overwritecondaddr" => "^10\.0\.0\.1$",
   );
 
+With an apache as reverse proxy (ssl-proxy.tld) you can use this configuration:
+
+::
+
+  ProxyPass "/domain.tld/owncloud" "http://domain.tld/owncloud"
+  ProxyPassReverse "/domain.tld/owncloud" "http://domain.tld/owncloud"
+
 .. note:: If you want to use the SSL proxy during installation you have to
   create the :file:`config/config.php` otherwise you have to extend the existing
   **$CONFIG** array.


### PR DESCRIPTION
This PR:

Applies the original patch from @romixch

>  I had some trouble configuring the reverse-proxy because of this issue: https://github.com/owncloud/core/issues/21760. I thought it could be useful to write down an example configuration for the proxy server.