### PR TITLE
Document the occ command to cleanup orphaned remote storages

### DIFF
--- a/admin_manual/configuration_server/background_jobs_configuration.rst
+++ b/admin_manual/configuration_server/background_jobs_configuration.rst
@@ -1,3 +1,5 @@
+.. _background-jobs-header:
+
 Background Jobs
 ========================
 

--- a/admin_manual/configuration_server/occ_command.rst
+++ b/admin_manual/configuration_server/occ_command.rst
@@ -1021,6 +1021,8 @@ So, to cleanup all orphaned remote storages, run it as follows::
 
   sudo -u www-data php sharing:cleanup-remote-storages
 
+You can also set it up to run as :ref:`a background job <background-jobs-header>`
+
 .. _shibboleth_label:
 
 Shibboleth Modes (Enterprise Edition only)

--- a/admin_manual/configuration_server/occ_command.rst
+++ b/admin_manual/configuration_server/occ_command.rst
@@ -1000,6 +1000,27 @@ Remove a certificate::
 
  sudo -u www-data php occ security:remove [certificate name]
 
+.. _sharing_commands_label:
+
+Sharing
+-------
+
+As of ownCloud 9.0, there is an occ command to cleanup orphaned remote storages.
+To explain why this is necessary, a little background is required.
+While shares are able to be deleted as a normal matter of course, remote storages with "shared::" are not included in this process.
+
+This might not, normally, be a problem.
+However, if a user has reshared a remote share which has been deleted it will.
+This is because when the original share is deleted, the remote re-share reference is not.
+Internally, the fileid will remain in the file cache and storage for that file will not be deleted.
+
+As a result, any user(s) who the share was reshared with will now get an errer when trying to access that file or folder.
+That's why the command is available.
+
+So, to cleanup all orphaned remote storages, run it as follows::
+
+  sudo -u www-data php sharing:cleanup-remote-storages
+
 .. _shibboleth_label:
 
 Shibboleth Modes (Enterprise Edition only)


### PR DESCRIPTION
This PR:

- documents the `occ` command to clean up orphaned remote storages, based on details in the links referenced in #2843. 

:information_desk_person: I'm not completely sure that it satisfies the request fully. But any further changes can be added as necessary.

### Relates To

#2843