### PR TITLE
Add double backslashes in rst admonition

### DIFF
--- a/admin_manual/configuration_server/background_jobs_configuration.rst
+++ b/admin_manual/configuration_server/background_jobs_configuration.rst
@@ -86,10 +86,10 @@ A number of existing background jobs are available to be run just for specific t
    and it becomes a bottleneck, then admins can delete several entries in the `oc_jobs` table and replace
    them with the corresponding `occ` command, which you can see here:
 
-   * `OCA\Files_Trashbin\BackgroundJob\ExpireTrash` -> `occ trashbin:expire`
-   * `OCA\Files_Versions\BackgroundJob\ExpireVersions` -> `occ versions:expire`
-   * `OCA\DAV\CardDAV\SyncJob` -> `occ dav:sync-system-addressbook`
-   * `OCA\Federation\SyncJob` -> `occ federation:sync-addressbooks`
+   * `OCA\\Files_Trashbin\\BackgroundJob\\ExpireTrash` -> `occ trashbin:expire`
+   * `OCA\\Files_Versions\\BackgroundJob\\ExpireVersions` -> `occ versions:expire`
+   * `OCA\\DAV\CardDAV\\SyncJob` -> `occ dav:sync-system-addressbook`
+   * `OCA\\Federation\\SyncJob` -> `occ federation:sync-addressbooks`
 
    If used, these should be scheduled to run on a daily basis.
 


### PR DESCRIPTION
These are, seemingly, being stripped on render. Adding double to ensure
that they are still present.