### PR TITLE
Fix documentation bugs

### DIFF
--- a/admin_manual/configuration_server/caching_configuration.rst
+++ b/admin_manual/configuration_server/caching_configuration.rst
@@ -199,14 +199,14 @@ Recommendations Based on Type of Deployment
 -------------------------------------------
 
 Small/Private Home Server
-^^^^^^^^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Only use APCu::
 
     'memcache.local' => '\OC\Memcache\APCu',
 
 Small Organization, Single-server Setup
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Use APCu for local caching, Redis for file locking::
 
@@ -218,7 +218,7 @@ Use APCu for local caching, Redis for file locking::
         ),
 
 Large Organization, Clustered Setup
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Use Redis for everything except local memcache. Use the server's IP address or hostname so that it is accessible to other hosts::
 
@@ -232,7 +232,7 @@ Use Redis for everything except local memcache. Use the server's IP address or h
         ),
 
 Additional notes for Redis vs. APCu on Memory Caching
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 APCu is faster at local caching than Redis. If you have enough memory, use APCu for Memory Caching
 and Redis for File Locking. If you are low on memory, use Redis for both.

--- a/admin_manual/enterprise_external_storage/windows-network-drive_configuration.rst
+++ b/admin_manual/enterprise_external_storage/windows-network-drive_configuration.rst
@@ -63,7 +63,7 @@ the server address, the share name, and the folder you want to connect to.
 2. Then select your authentication method; See :doc:`enterprise_only_auth` for 
    complete information on the five available authentication methods.
    
-.. figure:: images/wnd2.png
+.. figure:: images/wnd-2.png
    :alt: WND mountpoint and auth.
    
    *Figure 2: WND mountpoint and authorization credentials.*
@@ -182,17 +182,11 @@ following troubleshooting steps:
    shares are case-sensitive
 
 Take the example of attempting to connect to the share named `MyData` using
-``occ wnd:listen``. Running the following command would work
-
-.. highlight::
-   :linenos:
+``occ wnd:listen``. Running the following command would work::
   
    su www-data -s /bin/bash -c 'php /var/www/owncloud/occ wnd:listen dfsdata MyData svc_owncloud password'
 
-However, running this command would not:
-
-.. highlight::
-   :linenos:
+However, running this command would not::
    
    su www-data -s /bin/bash -c 'php /var/www/owncloud/occ wnd:listen dfsdata mydata svc_owncloud password'
 

--- a/admin_manual/installation/installation_wizard.rst
+++ b/admin_manual/installation/installation_wizard.rst
@@ -134,7 +134,7 @@ After you enter your temporary or root administrator login for your database, th
 creates a special database user with privileges limited to the ownCloud database. Then ownCloud
 needs only this special ownCloud database user and drops the temporary or root database login. 
 
-This new user is named from your ownCloud admin user, with an oc_ prefix, and then given a
+This new user is named from your ownCloud admin user, with an ``oc_`` prefix, and then given a
 random password.  The ownCloud database user and password are written into config.ph:
 
 | For MySQL/MariaDB:

--- a/admin_manual/maintenance/manually-moving-data-folders.rst
+++ b/admin_manual/maintenance/manually-moving-data-folders.rst
@@ -25,10 +25,10 @@ To save time, here's the commands which you can copy and use::
   ln -s /mnt/owncloud /www/owncloud/data
   apachectl -k graceful 
 
-.. NOTE:: 
-   If you're on CentOS/Fedora, try `systemctl restart httpd`.
-   If you're on Debian/Ubuntu try `sudo systemctl restart apache2`
-   To learn more about the systemctl command, please refer to `the systemd
+.. note:: 
+   If you're on CentOS/Fedora, try ``systemctl restart httpd``.
+   If you're on Debian/Ubuntu try ``sudo systemctl restart apache2``
+   To learn more about the systemctl command, please refer to `the systemd essentials guide`_
 
 Fix Hardcoded Database Path Variables
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/developer_manual/app/changelog.rst
+++ b/developer_manual/app/changelog.rst
@@ -21,6 +21,7 @@ The following breaking changes usually do only affect applications which misuse 
 
 Features
 ========
+
 * There is a new :doc:`OCSResponse and OCSController <controllers>` which allows you to easily migrate OCS code to the App Framework. This was added purely for compatibility reasons and the preferred way of doing APIs is using a :doc:`api`
 * You can now stream files in PHP by using the built in :doc:`StreamResponse <controllers>`.
 * For more advanced usecases you can now implement the :doc:`CallbackResponse <controllers>` interface which allows your response to do its own response rendering
@@ -42,12 +43,9 @@ This is a deprecation roadmap which lists all current deprecation targets and wi
 Deprecation Policy
 ------------------
 
-- An API added in one version of ownCloud only needs to be maintained as long as
-that version is not End of Life (EOL)
-- An API can be removed completely in a future version of ownCloud if the
-release date of the version is later than the EOL date of the previous version
-- Before removing an API completely, it needs to deprecated for at least a year.
-This is done by adding `@deprecated` tags.
+- An API added in one version of ownCloud only needs to be maintained as long as that version is not End of Life (EOL)
+- An API can be removed completely in a future version of ownCloud if the release date of the version is later than the EOL date of the previous version
+- Before removing an API completely, it needs to deprecated for at least a year. This is done by adding `@deprecated` tags.
 
 11.1
 ----

--- a/developer_manual/app/extstorage.rst
+++ b/developer_manual/app/extstorage.rst
@@ -25,9 +25,9 @@ Configure the filesystem type
 First, the :file:`/appinfo/info.xml` must be adjusted to specify the ``type`` as:
 ``filesystem``. For example:
 
-.. code-block:: xml
-
-.. include:: examples/storage-backend/appinfo/info.xml
+.. literalinclude:: ../examples/storage-backend/appinfo/info.xml
+     :language: xml
+     :linenos:
 
 Implement the storage class(es)
 ===============================
@@ -41,9 +41,9 @@ Here’s an example of how you would create one that implements all the
 filesystem operations required by ownCloud, using a fictitious library called
 ``FakeStorageLib``.
 
-.. code-block:: php
-
-.. include:: examples/storage-backend/OCA/MyStorageApp/Storage/MyStorage.php
+.. literalinclude:: ../examples/storage-backend/OCA/MyStorageApp/Storage/MyStorage.php
+     :language: php
+     :linenos:
 
 For this example we mapped the available storage methods to the ones from the
 library. Note that, in many cases, the underlying library might not support some
@@ -95,9 +95,9 @@ Create the backend adapter
 After implementing the storage class, a backend adapter needs to be created. To
 do that, create a class that extends from ``\\OCP\\Files\\External\\Backend``:
 
-.. code-block:: php
-
-.. include:: examples/storage-backend/OCA/MyStorageApp/Backend/MyStorageBackend.php
+.. literalinclude:: ../examples/storage-backend/OCA/MyStorageApp/Backend/MyStorageBackend.php
+     :language: php
+     :linenos:
 
 Definition parameters
 ---------------------
@@ -173,7 +173,7 @@ interface, as in the example below:
 
 .. code-block:: php
 
-.. include:: examples/storage-backend/OCA/MyStorageApp/AppInfo/Application.php
+  :include: examples/storage-backend/OCA/MyStorageApp/AppInfo/Application.php
 
 Then in :file:"appinfo/app.php" instantiate the ``Application`` class:
 


### PR DESCRIPTION
The most recent build of the documentation failed because of a series of RST formatting errors. This PR seeks to fix them all.