### PR TITLE
Add a troubleshooting entry about shares not appearing in the sidebar

### DIFF
--- a/user_manual/files/troubleshooting.rst
+++ b/user_manual/files/troubleshooting.rst
@@ -19,3 +19,11 @@ available, or broken it is likely that the operation will fail either at the
 beginning, or in the middle of the copy. 
 Other reasons for this message can be that, when writing to external storage,
 the connection took too long to respond or the network connection was flaky.
+
+Sharing sidebar does not show "Shared with you by ..." for remote shares 
+-------------------------------------------------------------------------
+
+In some scenarios, when users share folders and files with each other they cannot be scanned.
+There are a variety of reasons why this happen, which can include firewalls and broken servers. 
+In these situations, when the initial scan did not complete successfully, the mount point cannot appear in the ownCloud web UI. 
+This is because ownCloud was not able to generate a matching file cache entry, nor retrieve any metadata about whether it's a folder or file (mime type), etc.

--- a/user_manual/files/troubleshooting.rst
+++ b/user_manual/files/troubleshooting.rst
@@ -24,6 +24,6 @@ Sharing sidebar does not show "Shared with you by ..." for remote shares
 -------------------------------------------------------------------------
 
 In some scenarios, when users share folders and files with each other they cannot be scanned.
-There are a variety of reasons why this happen, which can include firewalls and broken servers. 
+There are a variety of reasons why this happens, which can include firewalls and broken servers. 
 In these situations, when the initial scan did not complete successfully, the mount point cannot appear in the ownCloud web UI. 
 This is because ownCloud was not able to generate a matching file cache entry, nor retrieve any metadata about whether it's a folder or file (mime type), etc.


### PR DESCRIPTION
This PR:

- Adds an entry to the troubleshooting guide for when shares cannot be scanned, and consequently do not appear in the sharing sidebar.