### PR TITLE
Corrected references to NGINX

### DIFF
--- a/admin_manual/configuration_files/big_file_upload_configuration.rst
+++ b/admin_manual/configuration_files/big_file_upload_configuration.rst
@@ -75,19 +75,19 @@ Apache with mod_fcgid
    Setting ``FcgidMaxRequestInMem`` significantly higher than normal may no longer be
    necessary, once bug #51747 is fixed.
 
-nginx
+NGINX
 ^^^^^
 * `client_max_body_size <http://nginx.org/en/docs/http/ngx_http_core_module.html#client_max_body_size>`_
 * `fastcgi_read_timeout <http://nginx.org/en/docs/http/ngx_http_fastcgi_module.html#fastcgi_read_timeout>`_
 * `client_body_temp_path <http://nginx.org/en/docs/http/ngx_http_core_module.html#client_body_temp_path>`_
 
-Since nginx 1.7.11 a new config option `fastcgi_request_buffering
+Since NGINX 1.7.11 a new config option `fastcgi_request_buffering
 <https://nginx.org/en/docs/http/ngx_http_fastcgi_module.html#fastcgi_request_buffering>`_
-is availabe. Setting this option to ``fastcgi_request_buffering off;`` in your nginx config
+is availabe. Setting this option to ``fastcgi_request_buffering off;`` in your NGINX config
 might help with timeouts during the upload. Furthermore it helps if you're running out of
 disc space on the tmp partition of your system.
 
-For more info how to configure nginx to raise the upload limits see also `this
+For more info how to configure NGINX to raise the upload limits see also `this
 <https://github.com/owncloud/documentation/wiki/Uploading-files-up-to-16GB#configuring-nginx>`_
 wiki entry.
 
@@ -97,7 +97,7 @@ wiki entry.
    performance, place these on a separate hard drive that is dedicated to 
    swap and temp storage.
    
-If your site is behind a nginx frontend (for example a loadbalancer): 
+If your site is behind a NGINX frontend (for example a loadbalancer): 
 
 By default, downloads will be limited to 1GB due to ``proxy_buffering`` and ``proxy_max_temp_file_size`` on the frontend.
 

--- a/admin_manual/configuration_server/harden_server.rst
+++ b/admin_manual/configuration_server/harden_server.rst
@@ -128,12 +128,12 @@ If you have subdomains not accessible via HTTPS, remove ``includeSubDomains``.
 
 .. note:: This requires the ``mod_headers`` extension in Apache.
 
-When using nginx as a Web server an example is already included in the
+When using NGINX as a Web server an example is already included in the
 :doc:`../installation/nginx_examples`::
 
   #add_header Strict-Transport-Security "max-age=15552000; includeSubDomains";
 
-You need to remove the ``#`` and reload nginx to enable this change.
+You need to remove the ``#`` and reload NGINX to enable this change.
 
 Proper SSL configuration
 ************************

--- a/admin_manual/configuration_server/index_php_less_urls.rst
+++ b/admin_manual/configuration_server/index_php_less_urls.rst
@@ -4,7 +4,7 @@ Enable index.php-less URLs
 Since ownCloud 9.0.3 you need to explicitly configure and enable index.php-less URLs
 (e.g. https://example.com/apps/files/ instead of https://example.com/index.php/apps/files/).
 The following documentation provides the needed steps to configure this for the ``Apache``
-Web server. These steps are not necessary when using nginx as a web server because it is already
+Web server. These steps are not necessary when using NGINX as a web server because it is already
 enabled in the :doc:`../installation/nginx_examples`.
 
 Prerequisites

--- a/admin_manual/installation/deployment_recommendations.rst
+++ b/admin_manual/installation/deployment_recommendations.rst
@@ -351,7 +351,7 @@ Cons:
 * Currently DB filecache table will grow rapidly, making migrations painful in 
   case the table is altered.
 
-What About Nginx / PHP-FPM?
+What About NGINX / PHP-FPM?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Could be used instead of HAproxy as the load balancer.
@@ -383,8 +383,8 @@ as SUSE Linux Enterprise Server.
 Web server
 ^^^^^^^^^^
 
-Taking Apache and Nginx as the contenders, Apache with mod_php is currently the 
-best option, as Nginx does not support all features necessary for enterprise 
+Taking Apache and NGINX as the contenders, Apache with mod_php is currently the 
+best option, as NGINX does not support all features necessary for enterprise 
 deployments. Mod_php is recommended instead of PHP_FPM, because in scale-out 
 deployments separate PHP pools are simply not necessary.
 

--- a/admin_manual/installation/nginx_examples.rst
+++ b/admin_manual/installation/nginx_examples.rst
@@ -1,18 +1,18 @@
 ============================
-nginx Example Configurations
+NGINX Example Configurations
 ============================
 
-This page covers example nginx configurations to use with running an ownCloud 
-server. Note that nginx is not officially supported, and this page is 
+This page covers example NGINX configurations to use with running an ownCloud 
+server. Note that NGINX is not officially supported, and this page is 
 community-maintained. (Thank you, contributors!)
 
--  You need to insert the following code into **your nginx configuration file.**
+-  You need to insert the following code into **your NGINX configuration file.**
 -  The configuration assumes that ownCloud is installed in 
    ``/var/www/owncloud`` and that it is accessed via 
    ``http(s)://cloud.example.com``.
 -  Adjust **server_name**, **root**, **ssl_certificate** and 
    **ssl_certificate_key** to suit your needs.
--  Make sure your SSL certificates are readable by the server (see `nginx HTTP 
+-  Make sure your SSL certificates are readable by the server (see `NGINX HTTP 
    SSL Module documentation <http://wiki.nginx.org/HttpSslModule>`_).
 -  ``add_header`` statements are only taken from the current level and are not 
    cascaded from or to a different level. All necessary ``add_header`` 
@@ -40,11 +40,11 @@ data in transit.
 -  Remove **ssl_certificate** and **ssl_certificate_key**.
 -  Remove **fastcgi_params HTTPS on;**
 
-ownCloud in the webroot of nginx
+ownCloud in the webroot of NGINX
 ================================
 
 The following config should be used when ownCloud is placed in the webroot of 
-your nginx installation.
+your NGINX installation.
 
 ::
 
@@ -135,7 +135,7 @@ your nginx installation.
           fastcgi_param front_controller_active true;
           fastcgi_pass php-handler;
           fastcgi_intercept_errors on;
-          fastcgi_request_buffering off; #Available since nginx 1.7.11
+          fastcgi_request_buffering off; #Available since NGINX 1.7.11
       }
   
       location ~ ^/(?:updater|ocs-provider)(?:$|/) {
@@ -168,11 +168,10 @@ your nginx installation.
       }
   }
 
-ownCloud in a subdir of nginx
+ownCloud in a subdir of NGINX
 =============================
 
-The following config should be used when ownCloud is not in your webroot but placed under a different contextroot of 
-your nginx installation such as /owncloud or /cloud. The following configuration assumes it is placed under ``/owncloud`` and that you have ``'overwritewebroot' => '/owncloud',`` set in your ``config/config.php``.
+The following config should be used when ownCloud is not in your webroot but placed under a different contextroot of your NGINX installation such as /owncloud or /cloud. The following configuration assumes it is placed under ``/owncloud`` and that you have ``'overwritewebroot' => '/owncloud',`` set in your ``config/config.php``.
 
 ::
 
@@ -276,7 +275,7 @@ your nginx installation such as /owncloud or /cloud. The following configuration
               fastcgi_read_timeout 180; # increase default timeout e.g. for long running carddav/ caldav syncs with 1000+ entries
               fastcgi_pass php-handler;
               fastcgi_intercept_errors on;
-              fastcgi_request_buffering off; #Available since nginx 1.7.11
+              fastcgi_request_buffering off; #Available since NGINX 1.7.11
           }
   
           location ~ ^/owncloud/(?:updater|ocs-provider)(?:$|/) {
@@ -317,7 +316,7 @@ Suppressing Log Messages
 If you're seeing meaningless messages in your logfile, for example `client 
 denied by server configuration: /var/www/data/htaccesstest.txt 
 <https://central.owncloud.org/t/htaccesstest-txt-errors-in-logfiles/831>`_,
-add this section to your nginx configuration to suppress them::
+add this section to your NGINX configuration to suppress them::
 
         location = /data/htaccesstest.txt {
           allow all;
@@ -328,7 +327,7 @@ add this section to your nginx configuration to suppress them::
 JavaScript (.js) or CSS (.css) files not served properly
 ========================================================
 
-A common issue with custom nginx configs is that JavaScript (.js)
+A common issue with custom NGINX configs is that JavaScript (.js)
 or CSS (.css) files are not served properly leading to a 404 (File not found)
 error on those files and a broken webinterface.
 
@@ -356,27 +355,27 @@ Performance Tuning
 `nginx (+1.9.5) <ngx_http_http2_module 
 <http://nginx.org/en/docs/http/ngx_http_v2_module.html>`_
 
-To use http_v2 for nginx you have to check two things:
+To use http_v2 for NGINX you have to check two things:
 
    1.) be aware that this module is not built in by default due to a dependency 
    to the openssl version used on your system. It will be enabled with the 
    ``--with-http_v2_module`` configuration parameter during compilation. The 
    dependency should be checked automatically. You can check the presence of 
    http_v2 with ``nginx -V 2>&1 | grep http_v2 -o``. An example of how to 
-   compile nginx can be found in section "Configure nginx with the 
+   compile NGINX can be found in section "Configure NGINX with the 
    ``nginx-cache-purge`` module" below.
    
-   2.) When you have used SPDY before, the nginx config has to be changed from 
+   2.) When you have used SPDY before, the NGINX config has to be changed from 
    ``listen 443 ssl spdy;`` to ``listen 443 ssl http2;``
 
-nginx: caching ownCloud gallery thumbnails
+NGINX: caching ownCloud gallery thumbnails
 ==========================================
 
-One of the optimizations for ownCloud when using nginx as the Web server is to 
-combine FastCGI caching with "Cache Purge", a `3rdparty nginx module 
+One of the optimizations for ownCloud when using NGINX as the Web server is to 
+combine FastCGI caching with "Cache Purge", a `3rdparty NGINX module 
 <http://wiki.nginx.org/3rdPartyModules>`_  that adds the ability to purge 
 content from `FastCGI`, `proxy`, `SCGI` and `uWSGI` caches. This mechanism 
-speeds up thumbnail presentation as it shifts requests to nginx and minimizes 
+speeds up thumbnail presentation as it shifts requests to NGINX and minimizes 
 php invocations which otherwise would take place for every thumbnail presented 
 every time.
  
@@ -384,25 +383,25 @@ The following procedure is based on an Ubuntu 14.04 system. You may need to
 adapt it according your OS type and release.
 
 .. note::
-   Unlike Apache, nginx does not dynamically load modules. All modules needed 
-   must be compiled into nginx. This is one of the reasons for nginx´s 
-   performance. It is expected to have an already running nginx installation 
+   Unlike Apache, NGINX does not dynamically load modules. All modules needed 
+   must be compiled into NGINX. This is one of the reasons for NGINX´s 
+   performance. It is expected to have an already running NGINX installation 
    with a working configuration set up as described in the ownCloud 
    documentation.
 
-nginx module check
+NGINX module check
 ==================
 
-As a first step, it is necessary to check if your nginx installation has the 
+As a first step, it is necessary to check if your NGINX installation has the 
 ``nginx cache purge`` module compiled in::
  
  nginx -V 2>&1 | grep ngx_cache_purge -o
  
 If your output contains ``ngx_cache_purge``, you can continue with the 
-configuration, otherwise you need to manually compile nginx with the module 
+configuration, otherwise you need to manually compile NGINX with the module 
 needed.
 
-Compile nginx with the ``nginx-cache-purge`` module
+Compile NGINX with the ``nginx-cache-purge`` module
 ===================================================
 
 1. **Preparation:**
@@ -423,13 +422,13 @@ distribution name)::
 Then run ``sudo apt-get update``
 
 .. note:: If you're not overly cautious and wish to install the latest and 
-   greatest nginx packages and features, you may have to install nginx from its 
-   mainline repository. From the nginx homepage: "In general, you should 
-   deploy nginx from its mainline branch at all times." If you would like to 
-   use standard nginx from the latest mainline branch but without compiling in 
+   greatest NGINX packages and features, you may have to install NGINX from its 
+   mainline repository. From the NGINX homepage: "In general, you should 
+   deploy NGINX from its mainline branch at all times." If you would like to 
+   use standard NGINX from the latest mainline branch but without compiling in 
    any additional modules, just run ``sudo apt-get install nginx``.   
 
-2. **Download the nginx source from the ppa repository**
+2. **Download the NGINX source from the ppa repository**
 
 ::
 
@@ -473,7 +472,7 @@ The parameters may now look like::
    --with-ipv6 \
    --add-module=$(MODULESDIR)/ngx_cache_purge
 
-4. **Compile and install nginx**
+4. **Compile and install NGINX**
 
 ::
 
@@ -491,28 +490,28 @@ The parameters may now look like::
     
 It should now show: ``ngx_cache_purge``
     
-Show nginx version including all features compiled and installed::
+Show NGINX version including all features compiled and installed::
 
    nginx -V 2>&1 | sed s/" --"/"\n\t--"/g
 
-6. **Mark nginx to be blocked from further updates via apt-get**
+6. **Mark NGINX to be blocked from further updates via apt-get**
 
 ::
 
    sudo dpkg --get-selections | grep nginx
     
-For every nginx component listed run ``sudo apt-mark hold <component>``   
+For every NGINX component listed run ``sudo apt-mark hold <component>``   
 
-7. **Regular checks for nginx updates**
+7. **Regular checks for NGINX updates**
 
-Do a regular visit on the `nginx news page <http://nginx.org>`_ and proceed 
+Do a regular visit on the `NGINX news page <http://nginx.org>`_ and proceed 
 in case of updates with items 2 to 5.
 
-Configure nginx with the ``nginx-cache-purge`` module
+Configure NGINX with the ``nginx-cache-purge`` module
 =====================================================
 
 1. **Preparation**
-   Create a directory where nginx will save the cached thumbnails. Use any 
+   Create a directory where NGINX will save the cached thumbnails. Use any 
    path that fits to your environment. Replace ``{path}`` in this example with 
    your path created:
    
@@ -574,7 +573,7 @@ Add *inside* the ``server{}`` block, as an example of a configuration::
    
 .. note:: Note regarding the ``fastcgi_pass`` parameter:
    Use whatever fits your configuration. In the example above, an ``upstream`` 
-   was defined in an nginx global configuration file.
+   was defined in an NGINX global configuration file.
    This may look like::
        
      upstream php-handler {

--- a/admin_manual/issues/general_troubleshooting.rst
+++ b/admin_manual/issues/general_troubleshooting.rst
@@ -219,7 +219,7 @@ these modules:
 * mod_spdy together with libapache2-mod-php5 / mod_php (use fcgi or php-fpm instead)
 * mod_xsendfile / X-Sendfile (causing broken downloads if not configured correctly)
 
-2. NginX
+2. NGINX
 
 * ngx_pagespeed
 * HttpDavModule
@@ -278,7 +278,7 @@ main Web server / Vhost configuration or the ``.htaccess`` placed in your docume
     RewriteCond %{REQUEST_METHOD} ^(OPTIONS)$
     RewriteRule .* https://%{SERVER_NAME}/owncloud/remote.php/webdav/ [R=301,L]
 
-For nginx an example config addition could be::
+For NGINX an example config addition could be::
 
     location = / {
         if ($http_user_agent = DavClnt) {

--- a/developer_manual/bugtracker/triaging.rst
+++ b/developer_manual/bugtracker/triaging.rst
@@ -52,7 +52,7 @@ Github offers several search queries which can be useful to find a list of bugs 
 * `Least commented issues <https://github.com/issues?q=is%3Aissue+user%3Aowncloud+is%3Aopen+no%3Aassignee+no%3Amilestone+no%3Alabel+sort%3Acomments-asc+>`_
 * `Bugs which need info <https://github.com/issues?q=is%3Aissue+user%3Aowncloud+is%3Aopen+label%3A%22Needs+info%22+sort%3Acreated-asc+>`_
 
-But there are more methods. For example, if you are a user of ownCloud with a specific setup like using nginx as Web server or dropbox as storage, or using the encryption app, you could look for bugs with these keywords. You can then use your knowledge of your installation and your installation itself to see if bugs are (still) valid or reproduce them.
+But there are more methods. For example, if you are a user of ownCloud with a specific setup like using NGINX as Web server or dropbox as storage, or using the encryption app, you could look for bugs with these keywords. You can then use your knowledge of your installation and your installation itself to see if bugs are (still) valid or reproduce them.
 
 Once you have picked an issue, add a comment that you've started triaging:
 
@@ -86,7 +86,7 @@ When the issue is a feature request, you can be helpful in the same way: merge r
 
 Determining relevance of issue
 ------------------------------
-Not all issues are relevant for ownCloud. Bugs can be due to a specific configuration or unsupported platforms. Raspberry Pi's suffer from SQLite time-outs, nginx has problems Apache doesn't and Microsoft Server with IIS is not well supported. While external issues are not always a reason to close a report, be sure that they are clear: does the user use the 'standard' platform? Ask for information if this is missing.
+Not all issues are relevant for ownCloud. Bugs can be due to a specific configuration or unsupported platforms. Raspberry Pi's suffer from SQLite time-outs, NGINX has problems Apache doesn't and Microsoft Server with IIS is not well supported. While external issues are not always a reason to close a report, be sure that they are clear: does the user use the 'standard' platform? Ask for information if this is missing.
 
 Last but not least, the problem might be due to the user doing something that simply does not work. Your general ownCloud knowledge might be helpful here - if this is the case, you can often swiftly close the issue with a comment about what went wrong.
 

--- a/developer_manual/testing/index.rst
+++ b/developer_manual/testing/index.rst
@@ -11,7 +11,7 @@ The ownCloud Test Pilots help to test and improve different server and client se
 
 Why do you want to join
 -----------------------
-There are many different setups and people have different interests. If we want ownCloud to run well on NginX for instance someone has to test this configuration.
+There are many different setups and people have different interests. If we want ownCloud to run well on NGINX for instance someone has to test this configuration.
 
 Furthermore, during bug fixing the ownCloud developers often do not have the possibility to reproduce the bug in a given environment nor they are able confirm that it was fixed. As a member of the Test Pilot Team you could act as a contact person for a specific area to help developers **fix the bugs you care about**. Testing ownCloud before it is released is the best way of making sure it does what you need it to!
 

--- a/user_manual/files/access_webdav.rst
+++ b/user_manual/files/access_webdav.rst
@@ -194,7 +194,7 @@ Accessing Files Using Mac OS X
 
 .. note:: The Mac OS X Finder suffers from a `series of implementation problems 
    <http://sabre.io/dav/clients/finder/>`_ and should only be used if the 
-   ownCloud server runs on **Apache** and **mod_php**, or **Nginx 1.3.8+**.
+   ownCloud server runs on **Apache** and **mod_php**, or **NGINX 1.3.8+**.
 
 To access files through the Mac OS X Finder:
 


### PR DESCRIPTION
This PR

- ensures that references to NGINX are written in the correct case. 

:information_desk_person: while minor in nature, it's still important to use names correctly,
whether they be of places, people, or products, etc.