### PR TITLE
Revise the PHPUnit installation and update related instructions

### DIFF
--- a/developer_manual/core/unit-testing.rst
+++ b/developer_manual/core/unit-testing.rst
@@ -1,33 +1,54 @@
 Unit-Testing
 ============
 
-PHP unit testing
-----------------
+PHP Unit Tests
+--------------
+
+ownCloud uses PHPUnit >= 4.8 for unit testing PHP code.
 
 Getting PHPUnit
 ~~~~~~~~~~~~~~~
 
-ownCloud uses PHPUnit >= 4.8 for unit testing.
+There are three ways to install it:
 
-To install it, either get it via your packagemanager::
+1. Use Composer
 
+::
+
+  composer require phpunit/phpunit
+
+2. Use your package manager (if you’re using a Linux distribution) 
+
+::
+
+  # When using a Debian-based distribution
   sudo apt-get install phpunit
 
-or install it manually::
+3. Install it manually
+
+::
 
   wget https://phar.phpunit.de/phpunit.phar
   chmod +x phpunit.phar
   sudo mv phpunit.phar /usr/local/bin/phpunit
 
-After the installation the ''phpunit'' command is available::
+After the installation the command ``phpunit`` is available
+
+::
 
   phpunit --version
+  
+.. important::
+   Please be aware that PHPUnit 6.0 and above require PHP 7.0.
   
 And you can update it using::
 
   phpunit --self-update
+  
+.. note::
+   This option is not supported from PHPUnit 6.0 onward. If you’re using this version or higher, please use either Composer or your package manager to upgrade to the latest version.
 
-You can find more information in the PHPUnit documentation: https://phpunit.de/manual/current/en/installation.html
+You can find more information in `the PHPUnit documentation`_.
 
 Writing PHP unit tests
 ~~~~~~~~~~~~~~~~~~~~~~
@@ -190,3 +211,7 @@ Here are some useful links about how to write unit tests with Jasmine and Sinon:
 - Jasmine: http://pivotal.github.io/jasmine
 - Sinon (for mocking and stubbing): http://sinonjs.org/ 
 
+
+.. links
+   
+.. _the PHPUnit documentation: https://phpunit.de/manual/current/en/installation.html

--- a/developer_manual/core/unit-testing.rst
+++ b/developer_manual/core/unit-testing.rst
@@ -9,6 +9,15 @@ ownCloud uses PHPUnit >= 4.8 for unit testing PHP code.
 Getting PHPUnit
 ~~~~~~~~~~~~~~~
 
+ownCloud >= 10.0
+^^^^^^^^^^^^^^^^
+
+If you are using ownCloud 10.0 or higher, running ``make test-php`` or ``make`` in your terminal from the root directory will install a local version of PHPUnit inside of ``lib/composer`` and run the test suite.
+
+ownCloud < 10.0
+^^^^^^^^^^^^^^^
+
+If you are on any version earlier than 10.0 you have to setup PHPUnit (and run the tests) manually. 
 There are three ways to install it:
 
 1. Use Composer
@@ -54,6 +63,7 @@ Writing PHP unit tests
 ~~~~~~~~~~~~~~~~~~~~~~
 
 To get started, do the following:
+
  - Create a directory called ``tests`` in the top level of your application
  - Create a php file in the directory and ``require_once`` your class which you want to test.
 
@@ -107,8 +117,8 @@ In :file:`/srv/http/owncloud/apps/myapp/` you run the test with::
 
 Make sure to extend the ``\Test\TestCase`` class with your test and always call the parent methods,
 when overwriting ``setUp()``, ``setUpBeforeClass()``, ``tearDown()`` or ``tearDownAfterClass()`` method
-from the TestCase. These methods set up important stuff and clean up the system after the test,
-so the next test can run without side effects, like remaining files and entries in the file cache, etc.
+from ``TestCase``. 
+These methods set up important stuff and clean up the system after the test, so the next test can run without side effects, like remaining files and entries in the file cache, etc.
 
 For more resources on PHPUnit visit: http://www.phpunit.de/manual/current/en/writing-tests-for-phpunit.html
 


### PR DESCRIPTION
This PR:

- Adds Composer to the list of installation options, listing it as the
first to indicate it's the preferred choice
- Adds a note indicating that PHPUnit 6 requires PHP 7.0
- Makes it clear that self-update is no longer available from PHPUnit 6

### Relates To

#2894