### PR TITLE
Update the database links at the top of Database Configuration section

### DIFF
--- a/admin_manual/configuration_database/linux_database_configuration.rst
+++ b/admin_manual/configuration_database/linux_database_configuration.rst
@@ -4,9 +4,9 @@ Database Configuration
 
 ownCloud requires a database in which administrative data is stored. The following databases are currently supported:
 
-* `MySQL <http://www.mysql.com/>`_ / `MariaDB <https://mariadb.org/>`_
-* `PostgreSQL <http://www.postgresql.org/>`_
-* `Oracle <http://www.oracle.com/>`_ (ownCloud Enterprise edition only)
+* :ref:`MySQL / MariaDB <db-binlog-label>`
+* :ref:`PostgreSQL <db-postgresql-label>`
+* :ref:`Oracle <db-oracle-database-setup>` (ownCloud Enterprise edition only)
 
 The MySQL or MariaDB databases are the recommended database engines.
 
@@ -143,6 +143,7 @@ this:
     "dbhost"        => "localhost",
     "dbtableprefix" => "oc_",
 
+.. _db-postgresql-label:
 
 PostgreSQL Database
 ~~~~~~~~~~~~~~~~~~~

--- a/admin_manual/enterprise_installation/oracle_db_configuration.rst
+++ b/admin_manual/enterprise_installation/oracle_db_configuration.rst
@@ -1,3 +1,5 @@
+.. _db-oracle-database-setup:
+
 =====================
 Oracle Database Setup
 =====================


### PR DESCRIPTION
This PR:

- links the database links at the top of the database configuration section to the information in the manual instead of to the respective vendor documentation. 

### Relates To

#2906