### PR TITLE
Move the Trusted Domains documentation to the migration docs

### DIFF
--- a/admin_manual/installation/installation_wizard.rst
+++ b/admin_manual/installation/installation_wizard.rst
@@ -28,7 +28,6 @@ to use the :doc:`occ Command <../configuration_server/occ_command>`.
 
 * :ref:`Data Directory Location <data_directory_location_label>`
 * :ref:`Database Choice <database_choice_label>`
-* :ref:`Trusted Domains <trusted_domains_label>`
 * :ref:`Setting Strong Permissions <strong_perms_label>`
 
 .. _data_directory_location_label:
@@ -153,34 +152,6 @@ Click Finish Setup, and start using your new ownCloud server.
    :alt: ownCloud welcome screen after a successful installation
 
 Now we will look at some important post-installation steps.
-
-.. _trusted_domains_label: 
-
-Trusted Domains
----------------
-
-All URLs used to access your ownCloud server must be whitelisted in your 
-``config.php`` file, under the ``trusted_domains`` setting. Users 
-are allowed to log into ownCloud only when they point their browsers to a 
-URL that is listed in the ``trusted_domains`` setting. You may use IP addresses 
-and domain names. A typical configuration looks like this::
-
- 'trusted_domains' => 
-   array (
-    0 => 'localhost', 
-    1 => 'server1.example.com', 
-    2 => '192.168.1.50',
- ),
-
-The loopback address, ``127.0.0.1``, is automatically whitelisted, so as long 
-as you have access to the physical server you can always log in. In the event 
-that a load balancer is in place there will be no issues as long as it sends 
-the correct X-Forwarded-Host header. When a user tries a URL that 
-is not whitelisted the following error appears:
-
-.. figure:: images/install-wizard-a4.png
-   :scale: 75%
-   :alt: Error message when URL is not whitelisted
   
 .. _strong_perms_label:
  

--- a/admin_manual/maintenance/migrating.rst
+++ b/admin_manual/maintenance/migrating.rst
@@ -39,8 +39,11 @@ Trusted Domains
 
 All URLs used to access your ownCloud server must be whitelisted in your 
 ``config.php`` file, under the ``trusted_domains`` setting. 
-Users are allowed to log into ownCloud only when they point their browsers to a 
-URL that is listed in the ``trusted_domains`` setting. 
+Users are allowed to log into ownCloud only when they point their browsers to a URL that is listed in the ``trusted_domains`` setting. 
+
+.. note:: 
+   This setting is important when changing or moving to a new domain name.
+
 You may use IP addresses and domain names. 
 A typical configuration looks like this::
 

--- a/admin_manual/maintenance/migrating.rst
+++ b/admin_manual/maintenance/migrating.rst
@@ -23,9 +23,39 @@ To start, let us be specific about the use case. A configured ownCloud instance 
 
 .. note:: You must keep the ``data/`` directory's original filepath. Do not change this!
 
-5. The data files should keep their original timestamp (can be done by using ``rsync`` with ``-t`` option) otherwise the clients will re-download all the files after the migration. This step might take several hours, depending on your installation.
+#. The data files should keep their original timestamp (can be done by using ``rsync`` with ``-t`` option) otherwise the clients will re-download all the files after the migration. This step might take several hours, depending on your installation.
 
 #.  With ownCloud still in maintenance mode (confirm!) and **BEFORE** changing the ``CNAME`` record in the DNS start up the database, Web server / application server on the new machine and point your Web browser to the migrated ownCloud instance. Confirm that you see the maintenance mode notice, that a logfile entry is written by both the Web server and ownCloud and that no error messages occur. Then take ownCloud out of maintenance mode and repeat. Log in as admin and confirm normal function of ownCloud.
 
 #.  Change the ``CNAME`` entry in the DNS to point your users to the new
     location.
+    
+With the ``CNAME`` updated, you now need to updated the trusted domains.
+    
+.. _trusted_domains_label: 
+
+Trusted Domains
+---------------
+
+All URLs used to access your ownCloud server must be whitelisted in your 
+``config.php`` file, under the ``trusted_domains`` setting. 
+Users are allowed to log into ownCloud only when they point their browsers to a 
+URL that is listed in the ``trusted_domains`` setting. 
+You may use IP addresses and domain names. 
+A typical configuration looks like this::
+
+ 'trusted_domains' => 
+   array (
+    0 => 'localhost', 
+    1 => 'server1.example.com', 
+    2 => '192.168.1.50',
+ ),
+
+The loopback address, ``127.0.0.1``, is automatically whitelisted, so as long as you have access to the physical server you can always log in. 
+In the event that a load balancer is in place there will be no issues as long as it sends the correct X-Forwarded-Host header. 
+When a user tries a URL that is not whitelisted the following error appears:
+
+.. figure:: images/install-wizard-a4.png
+   :scale: 75%
+   :alt: Error message when URL is not whitelisted
+


### PR DESCRIPTION
This PR:

- Relocates the Trusted Domains documentation to the migration section of the docs. Given the comments in the related ticket, it seemed the most logical place to put it.

### Relates To 

#2930 