### PR TITLE
Add separate ocdata var to permission script

### DIFF
--- a/admin_manual/installation/installation_wizard.rst
+++ b/admin_manual/installation/installation_wizard.rst
@@ -209,30 +209,34 @@ use :ref:`label-phpinfo` (Look for the **User/Group** line).
    lost.
 
 The easy way to set the correct permissions is to copy and run this script. 
-Replace the ``ocpath`` variable with the path to your ownCloud directory, and 
-replace the ``htuser`` and ``htgroup`` variables with your HTTP user and group::
+Replace the ``ocpath`` variable with the path to your ownCloud directory.
+Replace the ``ocdata`` variable with the path to your ownCloud data directory.
+Replace the ``htuser`` and ``htgroup`` variables with your HTTP user and group::
 
  #!/bin/bash
  ocpath='/var/www/owncloud'
+ ocdata='/var/www/owncloud/data'
  htuser='www-data'
  htgroup='www-data'
  rootuser='root'
 
  printf "Creating possible missing Directories\n"
- mkdir -p $ocpath/data
+ mkdir -p $ocdata
  mkdir -p $ocpath/assets
  mkdir -p $ocpath/updater
 
  printf "chmod Files and Directories\n"
  find ${ocpath}/ -type f -print0 | xargs -0 chmod 0640
  find ${ocpath}/ -type d -print0 | xargs -0 chmod 0750
+ find ${ocdata}/ -type f -print0 | xargs -0 chmod 0640
+ find ${ocdata}/ -type d -print0 | xargs -0 chmod 0750
 
  printf "chown Directories\n"
  chown -R ${rootuser}:${htgroup} ${ocpath}/
  chown -R ${htuser}:${htgroup} ${ocpath}/apps/
  chown -R ${htuser}:${htgroup} ${ocpath}/assets/
  chown -R ${htuser}:${htgroup} ${ocpath}/config/
- chown -R ${htuser}:${htgroup} ${ocpath}/data/
+ chown -R ${htuser}:${htgroup} ${ocdata}/
  chown -R ${htuser}:${htgroup} ${ocpath}/themes/
  chown -R ${htuser}:${htgroup} ${ocpath}/updater/
 
@@ -244,10 +248,10 @@ replace the ``htuser`` and ``htgroup`` variables with your HTTP user and group::
    chmod 0644 ${ocpath}/.htaccess
    chown ${rootuser}:${htgroup} ${ocpath}/.htaccess
  fi
- if [ -f ${ocpath}/data/.htaccess ]
+ if [ -f ${ocdata}/.htaccess ]
   then
-   chmod 0644 ${ocpath}/data/.htaccess
-   chown ${rootuser}:${htgroup} ${ocpath}/data/.htaccess
+   chmod 0644 ${ocdata}/.htaccess
+   chown ${rootuser}:${htgroup} ${ocdata}/.htaccess
  fi
  
 If you have customized your ownCloud installation and your filepaths are 


### PR DESCRIPTION
Add ocdata variable to the permissions script to more easily support installations with the data directory outside of the web root.