### PR TITLE
Fix broken render of PHP snippet

### DIFF
--- a/developer_manual/app/extstorage.rst
+++ b/developer_manual/app/extstorage.rst
@@ -43,7 +43,6 @@ filesystem operations required by ownCloud, using a fictitious library called
 
 .. literalinclude:: ../examples/storage-backend/OCA/MyStorageApp/Storage/MyStorage.php
      :language: php
-     :linenos:
 
 For this example we mapped the available storage methods to the ones from the
 library. Note that, in many cases, the underlying library might not support some
@@ -97,7 +96,6 @@ do that, create a class that extends from ``\\OCP\\Files\\External\\Backend``:
 
 .. literalinclude:: ../examples/storage-backend/OCA/MyStorageApp/Backend/MyStorageBackend.php
      :language: php
-     :linenos:
 
 Definition parameters
 ---------------------


### PR DESCRIPTION
I'm not sure why, but the `:linenos:` option seemed to break the code
rendering. It'll take a bit of research to see if there's something
about this version of Sphinx-Doc or something in the code snippet itself.