### PR TITLE
Galera cluster only supports ROW

### DIFF
--- a/admin_manual/configuration_database/linux_database_configuration.rst
+++ b/admin_manual/configuration_database/linux_database_configuration.rst
@@ -46,7 +46,7 @@ operations.
 
 The other is to change the BINLOG_FORMAT = STATEMENT in your database 
 configuration file, or possibly in your database startup script, to 
-BINLOG_FORMAT = MIXED. See `Overview of the Binary 
+BINLOG_FORMAT = MIXED or BINLOG_FORMAT = ROW. See `Overview of the Binary 
 Log <https://mariadb.com/kb/en/mariadb/overview-of-the-binary-log/>`_ and `The 
 Binary Log <https://dev.mysql.com/doc/refman/5.6/en/binary-log.html>`_ for 
 detailed information.


### PR DESCRIPTION
cc @settermjd @dercorn 

also see https://mariadb.com/kb/en/mariadb/binary-log-formats/ and http://galeracluster.com/documentation-webpages/configuration.html#configuring-database-server