### PR TITLE
Update the database requirements documentation for MySQL/MariaDB

### DIFF
--- a/admin_manual/installation/system_requirements.rst
+++ b/admin_manual/installation/system_requirements.rst
@@ -91,6 +91,6 @@ Database Requirements for MySQL / MariaDB
 
 The following are currently required if you're running ownCloud together with a MySQL or MariaDB database:
 
-* Disabled or BINLOG_FORMAT = MIXED configured Binary Logging (See: :ref:`db-binlog-label`)
+* Disabled or ``BINLOG_FORMAT = MIXED or BINLOG_FORMAT = ROW`` configured Binary Logging (See: :ref:`db-binlog-label`)
 * InnoDB storage engine (The MyISAM storage engine is not supported, see: :ref:`db-storage-engine-label`)
 * "READ COMMITED" transaction isolation level (See: :ref:`db-transaction-label`)

--- a/admin_manual/installation/system_requirements.rst
+++ b/admin_manual/installation/system_requirements.rst
@@ -91,6 +91,6 @@ Database Requirements for MySQL / MariaDB
 
 The following are currently required if you're running ownCloud together with a MySQL or MariaDB database:
 
-* Disabled or ``BINLOG_FORMAT = MIXED or BINLOG_FORMAT = ROW`` configured Binary Logging (See: :ref:`db-binlog-label`)
+* Disabled or ``BINLOG_FORMAT = MIXED`` or ``BINLOG_FORMAT = ROW`` configured Binary Logging (See: :ref:`db-binlog-label`)
 * InnoDB storage engine (The MyISAM storage engine is not supported, see: :ref:`db-storage-engine-label`)
 * "READ COMMITED" transaction isolation level (See: :ref:`db-transaction-label`)


### PR DESCRIPTION
As per [the comment](https://github.com/owncloud/documentation/pull/2990#issuecomment-292702438) in #2990, this PR updates the database requirements for MySQL & MariaDB.