### PR TITLE
Adding a note at section System Requirements / Memory

### DIFF
--- a/admin_manual/installation/system_requirements.rst
+++ b/admin_manual/installation/system_requirements.rst
@@ -8,9 +8,12 @@ Memory
 Memory requirements for running an ownCloud server are greatly variable,
 depending on the numbers of users and files, and volume of server activity.
 ownCloud officially requires a minimum of 128MB RAM. But, we recommend
-a minimum of 512MB. Consideration for for low memory environments: Scanning 
-of files is committed interally in 10k files chunks. Based on tests, server 
-memory usage for scanning +10k files used about 75MB of additional memory.
+a minimum of 512MB. 
+
+.. note:: *Consideration for low memory environments*
+   
+  Scanning of files is committed internally in 10k files chunks. 
+  Based on tests, server memory usage for scanning greater than 10k files uses about 75MB of additional memory.
 
 Recommended Setup for Running ownCloud
 --------------------------------------

--- a/admin_manual/installation/system_requirements.rst
+++ b/admin_manual/installation/system_requirements.rst
@@ -8,7 +8,9 @@ Memory
 Memory requirements for running an ownCloud server are greatly variable,
 depending on the numbers of users and files, and volume of server activity.
 ownCloud officially requires a minimum of 128MB RAM. But, we recommend
-a minimum of 512MB.
+a minimum of 512MB. Consideration for for low memory environments: Scanning 
+of files is committed interally in 10k files chunks. Based on tests, server 
+memory usage for scanning +10k files used about 75MB of additional memory.
 
 Recommended Setup for Running ownCloud
 --------------------------------------


### PR DESCRIPTION
Refs: https://github.com/owncloud/core/pull/27527
Adding a note regarding the memory usage caused by the scanner.
This is important for low memory systems.
The referenced core PR reduced the amount used greatly.