### PR TITLE
Chaned mysqldump parameter. There is no need to lock the tables at all.

### DIFF
--- a/admin_manual/maintenance/backup.rst
+++ b/admin_manual/maintenance/backup.rst
@@ -34,13 +34,13 @@ MySQL/MariaDB
 
 MySQL or MariaDB, which is a drop-in MySQL replacement, is the recommended database engine. To backup MySQL/MariaDB::
 
-    mysqldump --lock-tables -h [server] -u [username] -p[password] [db_name] > owncloud-dbbackup_`date +"%Y%m%d"`.bak
+    mysqldump --single-transaction -h [server] -u [username] -p[password] [db_name] > owncloud-dbbackup_`date +"%Y%m%d"`.bak
 
 
 
 Examle::
 
-      mysqldump --lock-tables -h localhost -u username -ppassword owncloud > owncloud-dbbackup_`date +"%Y%m%d"`.bak
+      mysqldump --single-transaction -h localhost -u username -ppassword owncloud > owncloud-dbbackup_`date +"%Y%m%d"`.bak
 
 
 SQLite


### PR DESCRIPTION
Hello,

I thought [this issue](https://github.com/nextcloud/documentation/issues/375) from the Nextcloud documentation would apply to the ownCloud documentation as well.

So, I changed the mysqldump parameter in this PR. If you accept the PR I will create backports for the other branches.

Regards,
Tronde