### PR TITLE
Update the systemctl commands to enable and start ClamAV

### DIFF
--- a/admin_manual/configuration_server/antivirus_configuration.rst
+++ b/admin_manual/configuration_server/antivirus_configuration.rst
@@ -116,8 +116,8 @@ hit the hardest for updates.
 Next, edit ``/etc/clamd.d/scan.conf``. When you're finished you must enable
 the ``clamd`` service file and start ``clamd``::
 
-  systemctl enable clamd@scan.service
-  systemctl start clamd@scan.service
+  systemctl enable clamav-daemon.service
+  systemctl start clamav-daemon.service
 
 That should take care of everything. Enable verbose logging in ``scan.conf``
 and ``freshclam.conf`` until it is running the way you want.


### PR DESCRIPTION
On working through the ClamAV/Anti-Virus documentation, while researching #2947, I found that the
previous systemctl commands didn't work. They may well work for a previous version of Ubuntu (I'm working with 16.04), but not for this version. Given that, this PR updates them so that they do work.