### PR TITLE
Document occ files:transfer-ownership --path switch

### DIFF
--- a/admin_manual/configuration_files/file_sharing_configuration.rst
+++ b/admin_manual/configuration_files/file_sharing_configuration.rst
@@ -68,13 +68,26 @@ Configure your sharing policy on your Admin page in the Sharing section.
 Transferring Files to Another User
 ----------------------------------
 
-You may transfer files from one user to another with ``occ``. This is useful 
-when you have to remove a user. Be sure to transfer the files before you delete 
-the user!  This transfers all files from user1 to user2, and the shares and 
-metadata info associated with those files (shares, tags, comments, etc). 
-Trashbin contents are not transferred::
+You may transfer files from one user to another with ``occ``. 
+The command transfers either all or a limited set of files from one user to another. 
+It also transfers the shares and metadata info associated with those files (*shares*, *tags*, and *comments*, etc). 
+This is useful when you have transfer a user’s files to another user before you delete them. 
+
+.. important:: 
+   Trashbin contents are not transferred.
+
+Here is an example of how to transfer all files from one user to another.
+
+::
 
  occ files:transfer-ownership user1 user2
+
+Here is an example of how to transfer *a limited group* of files from one user to another.
+In this example, ``"folder_name"`` is the name of the folder which you want to transfer ownership of — as well as all files and folders within it — between the two nominated users.
+
+::
+
+ occ files:transfer-ownership --path="folder_name" user1 user2
  
 (See :doc:`../configuration_server/occ_command` for a complete ``occ`` 
 reference.) 

--- a/admin_manual/configuration_files/file_sharing_configuration.rst
+++ b/admin_manual/configuration_files/file_sharing_configuration.rst
@@ -80,14 +80,19 @@ Here is an example of how to transfer all files from one user to another.
 
 ::
 
- occ files:transfer-ownership user1 user2
+ occ files:transfer-ownership <source-user> <destination-user>
 
-Here is an example of how to transfer *a limited group* of files from one user to another.
-In this example, ``"folder_name"`` is the name of the folder which you want to transfer ownership of — as well as all files and folders within it — between the two nominated users.
+Here is an example of how to transfer *a limited group* a single folder from one user to another.
+In it, ``folder/to/move``, and any file and folder inside it will be moved to ``<destination-user>``. 
 
 ::
 
- occ files:transfer-ownership --path="folder_name" user1 user2
+  sudo -u www-data php occ files:transfer-ownership --path="folder/to/move" <source-user> <destination-user>
+
+When using this command keep two things in mind: 
+
+1. The directory provided to the ``--path`` switch **must** exist inside ``data/<source-user>/files``.
+2. The directory (and its contents) won’t be moved as is between the users. It’ll be moved inside the destination user’s ``files`` directory, and placed in a directory which follows the format: ``transferred from <source-user> on <timestamp>``. Using the example above, it will be stored under: ``data/<destination-user>/files/transferred from <source-user> on 20170426_124510/``
  
 (See :doc:`../configuration_server/occ_command` for a complete ``occ`` 
 reference.) 

--- a/admin_manual/configuration_files/file_sharing_configuration.rst
+++ b/admin_manual/configuration_files/file_sharing_configuration.rst
@@ -71,7 +71,7 @@ Transferring Files to Another User
 You may transfer files from one user to another with ``occ``. 
 The command transfers either all or a limited set of files from one user to another. 
 It also transfers the shares and metadata info associated with those files (*shares*, *tags*, and *comments*, etc). 
-This is useful when you have transfer a user’s files to another user before you delete them. 
+This is useful when you have to transfer a user's files to another user before you delete them. 
 
 .. important:: 
    Trashbin contents are not transferred.

--- a/admin_manual/configuration_server/occ_command.rst
+++ b/admin_manual/configuration_server/occ_command.rst
@@ -635,15 +635,19 @@ For example, to move all files from ``<source-user>`` to ``<destination-user>``,
 
 ::
 
- sudo -u www-data php occ files:transfer-ownership <source-user>
- <destination-user>
+ sudo -u www-data php occ files:transfer-ownership <source-user> <destination-user>
 
-You can also move a limited set of files from ``<source-user>`` to ``<destination-user>``, by making use of the ``--path`` switch, as in the example below. 
-In it, only files (and folders) under ``data/folders/to/move`` will be moved.
+You can also move a limited set of files from ``<source-user>`` to ``<destination-user>`` by making use of the ``--path`` switch, as in the example below. 
+In it, ``folder/to/move``, and any file and folder inside it will be moved to ``<destination-user>``. 
 
 ::
 
- sudo -u www-data php occ files:transfer-ownership --path="data/folders/to/move" <source-user> <destination-user>
+  sudo -u www-data php occ files:transfer-ownership --path="folder/to/move" <source-user> <destination-user>
+
+When using this command keep two things in mind: 
+
+1. The directory provided to the ``--path`` switch **must** exist inside ``data/<source-user>/files``.
+2. The directory (and its contents) won’t be moved as is between the users. It’ll be moved inside the destination user’s ``files`` directory, and placed in a directory which follows the format: ``transferred from <source-user> on <timestamp>``. Using the example above, it will be stored under: ``data/<destination-user>/files/transferred from <source-user> on 20170426_124510/``
 
 .. _files_external_label:
 

--- a/admin_manual/configuration_server/occ_command.rst
+++ b/admin_manual/configuration_server/occ_command.rst
@@ -629,10 +629,21 @@ one must be specified.
 entries that have no matching entries in the storage table. 
 
 You may transfer all files and shares from one user to another. This is useful 
-before removing a user::
+before removing a user. 
+
+For example, to move all files from ``<source-user>`` to ``<destination-user>``, use the following command:
+
+::
 
  sudo -u www-data php occ files:transfer-ownership <source-user>
  <destination-user>
+
+You can also move a limited set of files from ``<source-user>`` to ``<destination-user>``, by making use of the ``--path`` switch, as in the example below. 
+In it, only files (and folders) under ``data/folders/to/move`` will be moved.
+
+::
+
+ sudo -u www-data php occ files:transfer-ownership --path="data/folders/to/move" <source-user> <destination-user>
 
 .. _files_external_label:
 


### PR DESCRIPTION
This PR:

- Documents the `--path` switch in occ `files:transfer-ownership` command, and fixes #2989 