### PR TITLE
Correct typos in example config file

### DIFF
--- a/admin_manual/configuration_ldap/examples/Multi-AD.slapd.conf
+++ b/admin_manual/configuration_ldap/examples/Multi-AD.slapd.conf
@@ -79,13 +79,13 @@ chase-referrals no
 # See slapd-meta
 
 
-# database type, for multiple ads "meta" is required
+# database type, for multiple ADS "meta" is required
 
 database	meta
 
 # now we create a local ldap tree
 
-# in our tree we put the multiple ads on different branches
+# in our tree we put the multiple ADS on different branches
 
 # we need a suffix, an admin, and a password
 
@@ -165,7 +165,7 @@ pcache hdb 100000 3 1000 100
 
 pcachePersist TRUE
 
-# Where the database file are physically stored for database #1
+# Where the database files are physically stored for database #1
 
 directory       "/var/lib/ldap"
 
@@ -178,7 +178,7 @@ directory       "/var/lib/ldap"
 pcacheAttrset   0 1.1
 
 # pcacheTemplate <template_string> <attrset_index> <ttl>
-# First define the querry sting to cache
+# First define the query sting to cache
 # Then reference the Attrset
 # Last set the time-to-live
 


### PR DESCRIPTION
@phil-davis pointed out some minor corrections required in Multi-AD.slapd.conf in https://github.com/owncloud/documentation/pull/2954#discussion_r113193745. This PR addresses those corrections.