### PR TITLE
Add reference to the "name" option in the OCS Share API

### DIFF
--- a/developer_manual/core/ocs-share-api.rst
+++ b/developer_manual/core/ocs-share-api.rst
@@ -247,6 +247,8 @@ Function Arguments
 ============ ======= ==========================================================
 Argument     Type    Description 
 ============ ======= ==========================================================
+name         string  a (human-readable) name for the share, which can be up to
+                     64 characters in length
 path         string  path to the file/folder which should be shared
 shareType    int     The type of the share. This can be one of: 0 = user, 
                      1 = group, 3 = public link, 6 = federated cloud share
@@ -357,6 +359,8 @@ share_with_displayname string   The display name of the receiver of the file.
 url                    string
 mail_send              int      Whether the recipient was notified, by mail, about the 
                                 share being shared with them.
+name                   string   A (human-readable) name for the share, which can be up 
+                                to 64 characters in length
 ====================== ======== ========================================================
 
 .. _ocs-share-api__delete-share:
@@ -437,6 +441,8 @@ Request Arguments
 ============ ======= ==================================================
 Argument     Type    Description
 ============ ======= ==================================================
+name         string  A (human-readable) name for the share, which can 
+                     be up to 64 characters in length
 share_id     int     The share’s unique id
 permissions  int     Update permissions 
                      (see :ref:`the create share section 

--- a/developer_manual/examples/curl/create-share.sh
+++ b/developer_manual/examples/curl/create-share.sh
@@ -7,5 +7,5 @@ SERVER_URI=https://your.owncloud.install.com/owncloud
 API_PATH=ocs/v1.php/apps/files_sharing/api/v1
 
 curl --user your.username:your.password "$SERVER_URI/$API_PATH/shares" \
-     --data 'path=/Photos/Paris.jpg&shareType=3&permissions=1'
+     --data 'path=/Photos/Paris.jpg&shareType=3&permissions=1&name=paris photo'
 

--- a/developer_manual/examples/curl/create-share.sh
+++ b/developer_manual/examples/curl/create-share.sh
@@ -7,5 +7,5 @@ SERVER_URI=https://your.owncloud.install.com/owncloud
 API_PATH=ocs/v1.php/apps/files_sharing/api/v1
 
 curl --user your.username:your.password "$SERVER_URI/$API_PATH/shares" \
-     --data 'path=/Photos/Paris.jpg&shareType=3&permissions=1&name=paris photo'
+     --data 'path=/Photos/Paris.jpg&shareType=3&permissions=1&name=paris%20photo'
 

--- a/developer_manual/examples/curl/update-share.sh
+++ b/developer_manual/examples/curl/update-share.sh
@@ -8,5 +8,5 @@ API_PATH=ocs/v1.php/apps/files_sharing/api/v1
 
 curl --user your.username:your.password "$SERVER_URI/$API_PATH/shares/115470" \
      --request PUT \
-     --data 'expireDate=2017-01-02&name=paris photo'
+     --data 'expireDate=2017-01-02&name=paris%20photo'
 

--- a/developer_manual/examples/curl/update-share.sh
+++ b/developer_manual/examples/curl/update-share.sh
@@ -8,5 +8,5 @@ API_PATH=ocs/v1.php/apps/files_sharing/api/v1
 
 curl --user your.username:your.password "$SERVER_URI/$API_PATH/shares/115470" \
      --request PUT \
-     --data 'expireDate=2017-01-02'
+     --data 'expireDate=2017-01-02&name=paris photo'
 

--- a/developer_manual/examples/responses/shares/create-share-success.xml
+++ b/developer_manual/examples/responses/shares/create-share-success.xml
@@ -30,5 +30,6 @@
     <share_with_displayname/>
     <url>https://your.owncloud.install.com/owncloud/index.php/s/MMqyHrR0GTepo4B</url>
     <mail_send>0</mail_send>
+    <name>paris photo</name>
   </data>
 </ocs>

--- a/developer_manual/examples/responses/shares/get-share-info-success.xml
+++ b/developer_manual/examples/responses/shares/get-share-info-success.xml
@@ -29,6 +29,7 @@
       <file_target></file_target>
       <share_with>user@example.com</share_with>
       <share_with_displayname>user@example.com</share_with_displayname>
+      <name>ownCloud Manual</name>
       <mail_send>0</mail_send>
     </element>
   </data>

--- a/developer_manual/examples/responses/shares/update-share-success.xml
+++ b/developer_manual/examples/responses/shares/update-share-success.xml
@@ -30,5 +30,6 @@
     <share_with_displayname/>
     <url>https://your.owncloud.install.com/owncloud/index.php/s/11CUiVe0l7iaIwM</url>
     <mail_send>0</mail_send>
+    <name>paris photo</name>
   </data>
 </ocs>


### PR DESCRIPTION
This PR:

- Documents the new `name` option in the [OCS Share API](https://doc.owncloud.org/server/10.0/developer_manual/core/ocs-share-api.html), introduced in
https://github.com/owncloud/core/commit/1bc67dd44aa8a3ada6b610b1b4186b2251d55a15 by @PVince81. 

### Relates To 

#2957