### PR TITLE
Backport supported linux distro policy to stable9

### DIFF
--- a/admin_manual/installation/system_requirements.rst
+++ b/admin_manual/installation/system_requirements.rst
@@ -12,7 +12,7 @@ ownCloud needs a minimum of 128MB RAM, and we recommend a minimum of 512MB.
 Recommended Setup for Running ownCloud
 --------------------------------------
 
-For best performance, stability, support, and full functionality we recommend:
+For *best performance*, *stability*, *support*, and *full functionality* we officially recommend and support:
 
 * Ubuntu 16.04
 * MySQL/MariaDB
@@ -58,6 +58,8 @@ Desktop
 - Windows 7+
 - Mac OS X 10.7+ (64-bit only)
 
+For Linux distributions, we support, if technically feasible, the latest 2 versions per platform and the previous `LTS`_.
+These are:
 
 - Ubuntu 16.10
 - Ubuntu 16.04
@@ -69,9 +71,6 @@ Desktop
 - Fedora 25
 - openSUSE Leap 42.1
 - openSUSE Leap 42.2
-
-.. note::
-   For Linux distributions, we support, if technically feasible, the latest 2 versions per platform and the previous `LTS`_.
 
 Mobile 
 ^^^^^^

--- a/admin_manual/installation/system_requirements.rst
+++ b/admin_manual/installation/system_requirements.rst
@@ -22,22 +22,72 @@ For best performance, stability, support, and full functionality we recommend:
 Supported Platforms
 -------------------
 
-* Server: Linux (Debian 7, SUSE Linux Enterprise Server 11 SP3 & 12, 
-  Red Hat Enterprise Linux/Centos 6.5 and 7 (7 is 64-bit only), Ubuntu 12.04 
-  LTS, 14.04 LTS, 14.10)
-* Web server: Apache 2 with mod_php
-* Databases: MySQL/MariaDB 5.5+; Oracle 11g (ownCloud Enterprise edition only); PostgreSQL
-* PHP: Minimum 5.6, maximum 7.0
-* Hypervisors: Hyper-V, VMware ESX, Xen, KVM
-* Desktop: Windows XP SP3 (EoL Q2 2015), Windows 7+, Mac OS X 10.7+ (64-bit 
-  only), Linux (CentOS 6.5, 7 (7 is 64-bit only), Ubuntu 12.04 LTS, 14.04 LTS, 
-  14.10, Fedora 20, 21, openSUSE 12.3, 13, Debian 7 & 8).
-* Mobile apps: iOS 7+, Android 4+
-* Web browser: IE9+ (except Compatibility Mode), Firefox 14+, Chrome 18+, 
-  Safari 5+
+If you are not able to use one or more of the above tools, the following
+options are also supported. 
 
-See :doc:`source_installation` for minimum software versions for installing 
-ownCloud.
+Server
+^^^^^^
+
+- Debian 7 and 8
+- SUSE Linux Enterprise Server 12 and 12 SP1
+- Red Hat Enterprise Linux/Centos 6.5 and 7 (**7 is 64-bit only**)
+- Ubuntu 14.04 LTS
+
+Web Server
+^^^^^^^^^^
+
+- Apache 2.4 with mod_php
+
+Databases
+^^^^^^^^^
+
+- Oracle 11g (**Enterprise edition only**)
+- PostgreSQL
+
+Hypervisors 
+^^^^^^^^^^^
+
+- Hyper-V
+- VMware ESX
+- Xen
+- KVM
+
+Desktop
+^^^^^^^
+
+- Windows 7+
+- Mac OS X 10.7+ (64-bit only)
+
+
+- Ubuntu 16.10
+- Ubuntu 16.04
+- Ubuntu 14.04
+- Debian 7.0
+- Debian 8.0
+- CentOS 7
+- Fedora 24
+- Fedora 25
+- openSUSE Leap 42.1
+- openSUSE Leap 42.2
+
+.. note::
+   For Linux distributions, we support, if technically feasible, the latest 2 versions per platform and the previous `LTS`_.
+
+Mobile 
+^^^^^^
+
+- iOS 9.0+
+- Android 4.0+
+
+Web Browser 
+^^^^^^^^^^^
+
+- IE11+ (except Compatibility Mode)
+- Firefox 14+
+- Chrome 18+
+- Safari 5+
+
+See :doc:`source_installation` for minimum software versions for installing ownCloud.
 
 Database Requirements for MySQL / MariaDB
 -----------------------------------------
@@ -47,3 +97,7 @@ The following is currently required if you're running ownCloud together with a M
 * Disabled or BINLOG_FORMAT = MIXED configured Binary Logging (See: :ref:`db-binlog-label`)
 * InnoDB storage engine (MyISAM is not supported, see: :ref:`db-storage-engine-label`)
 * "READ COMMITED" transaction isolation level (See: :ref:`db-transaction-label`)
+
+.. Links
+   
+.. _LTS: https://wiki.ubuntu.com/LTS


### PR DESCRIPTION
As requested in #2996, this PR backports the supported Linux distro policy to stable9.