### PR TITLE
Caution against running some cron jobs in parallel on multiple servers

### DIFF
--- a/admin_manual/configuration_server/background_jobs_configuration.rst
+++ b/admin_manual/configuration_server/background_jobs_configuration.rst
@@ -130,6 +130,13 @@ It can be run, as follows, using the OCC command::
 
   occ versions:expire
 
+.. WARNING:: 
+   Please take care when adding ``ExpireTrash`` and ``ExpireVersions`` as `Cron`_ jobs.
+   Make sure that they’re not started in parallel on multiple machines. 
+   Running in parallel on a single machine is fine. 
+   But, currently, there isn’t sufficient locking in place to prevent them from conflicting 
+   with each other if running in parallel across multiple machines. 
+
 SyncJob (CardDAV)
 ^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
This PR: 

- adds an admonition to make it clear to users that `ExpireTrash` and `ExpireVersions` cannot be run in parallel on multiple machines simultaneously.

## Relates To

owncloud/enterprise/issues/1882