### PR TITLE
Backport the document policy for the supported Linux distributions changes to stable9.1

### DIFF
--- a/admin_manual/installation/system_requirements.rst
+++ b/admin_manual/installation/system_requirements.rst
@@ -67,10 +67,6 @@ Desktop
 
 - Windows 7+
 - Mac OS X 10.7+ (64-bit only)
-
-For Linux distributions, we support, if technically feasible, the latest 2 versions per platform and the previous `LTS`_.
-These are:
-
 - Ubuntu 16.10
 - Ubuntu 16.04
 - Ubuntu 14.04
@@ -81,6 +77,9 @@ These are:
 - Fedora 25
 - openSUSE Leap 42.1
 - openSUSE Leap 42.2
+
+.. note::
+   For Linux distributions, we support, if technically feasible, the latest 2 versions per platform and the previous `LTS`_.
 
 Mobile 
 ^^^^^^


### PR DESCRIPTION
This PR backports the changes in #2996 to stable9.1.
