### PR TITLE
Backport the document policy changes for the supported Linux distributions to stable9.

### DIFF
--- a/admin_manual/installation/system_requirements.rst
+++ b/admin_manual/installation/system_requirements.rst
@@ -57,10 +57,6 @@ Desktop
 
 - Windows 7+
 - Mac OS X 10.7+ (64-bit only)
-
-For Linux distributions, we support, if technically feasible, the latest 2 versions per platform and the previous `LTS`_.
-These are:
-
 - Ubuntu 16.10
 - Ubuntu 16.04
 - Ubuntu 14.04
@@ -71,6 +67,9 @@ These are:
 - Fedora 25
 - openSUSE Leap 42.1
 - openSUSE Leap 42.2
+
+.. note::
+   For Linux distributions, we support, if technically feasible, the latest 2 versions per platform and the previous `LTS`_.
 
 Mobile 
 ^^^^^^


### PR DESCRIPTION
This backports the changes in #2996 to stable9. This isn't a major change, simply ensuring consistency across the documentation versions.