### PR TITLE
Update user manual link to client docs to the latest version

### DIFF
--- a/user_manual/index.rst
+++ b/user_manual/index.rst
@@ -23,6 +23,6 @@ manuals:
 * `ownCloud Android App`_
 * `ownCloud iOS App`_ 
 
-.. _`ownCloud Desktop Client`: https://doc.owncloud.org/desktop/2.1/
+.. _`ownCloud Desktop Client`: https://doc.owncloud.org/desktop/latest/
 .. _`ownCloud Android App`: https://doc.owncloud.org/android/
 .. _`ownCloud iOS App`: https://doc.owncloud.org/ios/


### PR DESCRIPTION
This fixes #3070. When merged, I'll backport the changes to stable9.1 and stable9