### PR TITLE
Backport the MySQL / MariaDB database requirements updates

### DIFF
--- a/admin_manual/configuration_database/linux_database_configuration.rst
+++ b/admin_manual/configuration_database/linux_database_configuration.rst
@@ -51,13 +51,17 @@ Log <https://mariadb.com/kb/en/mariadb/overview-of-the-binary-log/>`_ and `The
 Binary Log <https://dev.mysql.com/doc/refman/5.6/en/binary-log.html>`_ for 
 detailed information.
 
-.. _db-storage-engine-label:
+.. _db-transaction-label:
 
-MySQL / MariaDB storage engine
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+MySQL / MariaDB "READ COMMITED" transaction isolation level
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Since ownCloud 7 only InnoDB is supported as a storage engine. There are some shared hosters that
-do not support InnoDB and only MyISAM. Running ownCloud on such an environment is not supported.
+As discussed above ownCloud is using the ``TRANSACTION_READ_COMMITTED`` transaction isolation
+level. Some database configurations are enforcing other transaction isolation levels. To avoid
+data loss under high load scenarios (e.g. by using the sync client with many clients/users and
+many parallel operations) you need to configure the transaction isolation level accordingly.
+Please refer to the `MySQL manual <https://dev.mysql.com/doc/refman/5.7/en/set-transaction.html>`_
+for detailed information.
 
 Parameters
 ----------


### PR DESCRIPTION
This is being done as part of the fix for #2972. Another backport will be performed on stable9.0 shortly. 