### PR TITLE
Streamlined the wording of the local storages section

### DIFF
--- a/admin_manual/configuration_files/external_storage/local.rst
+++ b/admin_manual/configuration_files/external_storage/local.rst
@@ -2,34 +2,28 @@
 Local
 =====
 
-Local storages provide access to any directory on the ownCloud server. Since
-this is a significant security risk, Local storage can only be configured in
-the ownCloud admin settings. Non-admin users cannot create Local storage 
-mounts. 
+Local storages provide the ability to mount any directory on your ownCloud server that is:
 
-Use this to mount any directory on your ownCloud server that is outside 
-of your ownCloud ``data/`` directory. This directory must be readable and 
-writable by your HTTP server user. These ownership and permission examples 
-are on Ubuntu Linux::
+- Outside of your ownCloud ``data/`` directory
+- Both readable and writable by your HTTP server user 
 
- sudo -u www-data chown -R www-data:www-data /localdir
- sudo -u www-data chmod -R 0750 /localdir
+Since this is a significant security risk, Local storage is only configurable via the ownCloud admin settings. 
+Non-admin users cannot create Local storage mounts. 
  
-See :ref:`strong_perms_label` for information on correct file permissions, and 
-find your HTTP user :ref:`label-phpinfo`.
- 
-In the **Folder name** field enter the folder name that you want to appear on 
-your ownCloud Files page.
-
-In the **Configuration** field enter the full filepath of the directory you 
-want to mount.
-
-In the **Available for** field enter the users or groups who have permission to 
-access the mount. By default all users have access.
+.. note::
+   See :ref:`strong_perms_label` for information on correct file permissions, and find your HTTP user :ref:`label-phpinfo`.
+   
+To manage Local storages, navigate to ``admin``, then ``Storage``. 
+You can see an example in the screenshot below.
 
 .. figure:: images/local.png
+   
+In the **Folder name** field enter the folder name that you want to appear on your ownCloud Files page.
 
-See :doc:`../external_storage_configuration_gui` for additional mount 
-options and information.
+In the **Configuration** field enter the full file path of the directory you want to mount.
 
-See :doc:`auth_mechanisms` for more information on authentication schemes.
+In the **Available for** field enter the users or groups who have permission to access the mount. 
+By default all users have access.
+
+.. note::
+   See :doc:`../external_storage_configuration_gui` for additional mount options and information, and :doc:`auth_mechanisms` for more information on authentication schemes.


### PR DESCRIPTION
Not, strictly, necessary. But the content is now more succinct and more rapidly digestible.