### PR TITLE
Client: Update supported Linux distributions

### DIFF
--- a/admin_manual/installation/system_requirements.rst
+++ b/admin_manual/installation/system_requirements.rst
@@ -70,12 +70,13 @@ Desktop
 - Mac OS X 10.7+ (64-bit only)
 
 
+- Ubuntu 17.04
 - Ubuntu 16.10
 - Ubuntu 16.04
 - Ubuntu 14.04
 - Debian 7.0
 - Debian 8.0
-- CentOS 7
+- CentOS 7 (64-bit only)
 - Fedora 24
 - Fedora 25
 - openSUSE Leap 42.1


### PR DESCRIPTION
@settermjd With the 2.3.2 release, support for Ubuntu 17.04 has been added.

Fix:
CentOS 7 has never been officially released in 32-bit flavour.

Please backport for older server versions too.