### PR TITLE
Deprecate the show-remnants documentation

### DIFF
--- a/admin_manual/configuration_server/config_sample_php_parameters.rst
+++ b/admin_manual/configuration_server/config_sample_php_parameters.rst
@@ -985,11 +985,9 @@ Global settings used by LDAP User and Group Backend
 
 	'ldapUserCleanupInterval' => 51,
 
-defines the interval in minutes for the background job that checks user
-existence and marks them as ready to be cleaned up. The number is always
-minutes. Setting it to 0 disables the feature.
-
-See command line (occ) methods ldap:show-remnants and user:delete
+This defines the interval in minutes for the background job that checks user existence and marks them as ready to be cleaned up. 
+The number is always minutes. 
+Setting it to ``0`` disables the feature.
 
 Comments
 --------

--- a/admin_manual/configuration_server/occ_command.rst
+++ b/admin_manual/configuration_server/occ_command.rst
@@ -740,9 +740,6 @@ you can run the following LDAP commands with ``occ``::
   ldap:search                   executes a user or group search
   ldap:set-config               modifies an LDAP configuration
   ldap:show-config              shows the LDAP configuration
-  ldap:show-remnants            shows which users are not available on 
-                                LDAP anymore, but have remnants in 
-                                ownCloud.
   ldap:test-config              tests an LDAP configuration
   ldap:update-group             update the specified group membership
                                 information stored locally


### PR DESCRIPTION
This PR removes details about the `show-remnants` command from the documentation, as it is no longer required (confirmed by @tomneedham). 

### Relates To 

#3132 
