### PR TITLE
Fix broken link to cron jobs in the release notes

### DIFF
--- a/admin_manual/configuration/server/background_jobs_configuration.rst
+++ b/admin_manual/configuration/server/background_jobs_configuration.rst
@@ -13,6 +13,8 @@ Cron jobs are commands or shell-based scripts that are scheduled to periodically
 ownCloud plug-in applications can register actions with ``cron.php`` automatically to take care of typical housekeeping operations. 
 These actions can include garbage collecting of temporary files or checking for newly updated files using ``filescan()`` on externally mounted file systems.
 
+.. _cron_job_label:
+
 Cron Jobs
 ---------
 

--- a/admin_manual/release_notes.rst
+++ b/admin_manual/release_notes.rst
@@ -90,7 +90,7 @@ Existing LDAP users only show up in the user management page and the share dialo
 The account table introduced in ownCloud 10.0.0 significantly reduces LDAP communication overhead. 
 Password checks are yet to be accounted for. 
 LDAP user metadata in the account table will be updated when users log in or when the administrator runs ``occ user:sync "OCA\User_LDAP\User_Proxy"``.
-We recommend `setting up a nightly Cron job`_ to keep metadata of users not actively logging in up to date.
+We recommend :ref:`setting up a nightly Cron job <cron_job_label>` to keep metadata of users not actively logging in up to date.
 
 Error pages will not use the configured theme but will instead fall back to the community default
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
This PR fixes a broken link in the release notes reported in [a comment in #3106](https://github.com/owncloud/documentation/issues/3106#issuecomment-312474650).