### PR TITLE
Pull UI test start commands out on their own lines

### DIFF
--- a/developer_manual/core/ui-testing.rst
+++ b/developer_manual/core/ui-testing.rst
@@ -39,10 +39,19 @@ Set Up Test
     export SRV_HOST_PORT=80
     export BROWSER=chrome
 
-- If you don't have a webserver already running start the PHP development server with:
-  ``bash tests/travis/start_php_dev_server.sh`` (leave SRV_HOST_URL empty in that case. ``export SRV_HOST_URL=""``).
-  The server will bind to: ``$SRV_HOST_NAME:$SRV_HOST_PORT``.
-- Run the tests: ``bash tests/travis/start_behat_tests.sh``.
+- If you don't have a webserver already running, leave SRV_HOST_URL empty ( ``export SRV_HOST_URL=""`` ), and start the PHP development server with:
+
+.. code-block:: console
+
+  bash tests/travis/start_php_dev_server.sh
+
+The server will bind to: ``$SRV_HOST_NAME:$SRV_HOST_PORT``.
+
+- Run the tests:
+
+.. code-block:: console
+
+  bash tests/travis/start_behat_tests.sh
 
 The tests need to be run as the same user who is running the webserver and this user must be also owner of the config file (``config/config.php``).
 To run the tests as user that is different to your current terminal user use ``sudo -E -u <username>`` e.g. to run as 'www-data' user ``sudo -E -u www-data bash tests/travis/start_behat_tests.sh``.


### PR DESCRIPTION
These commands were a bit buried in the text.
IMHO it it nicer to have them on their own lines where they can more easily be cut-pasted by readers.