### PR TITLE
Add repository instructions for when installing ownCloud

### DIFF
--- a/admin_manual/installation/linux_installation.rst
+++ b/admin_manual/installation/linux_installation.rst
@@ -37,15 +37,15 @@ the ``owncloud-files`` package for your distro:
 
 ownCloud packages with dependencies are available for the following Linux distributions:
 
-* Ubuntu 14.04, 16.04
-* Debian 8
-* RHEL 7
-* CentOS 7
-* SLES 12
-* openSUSE 13.2, Leap 42.1
+* Ubuntu 14.04 & 16.04
+* Debian 7 & 8
+* RHEL 6 & 7
+* CentOS 7.2 & 7.3
+* SLES 11SP4 & 12SP2
+* openSUSE Leap 42.2 & 42.3
 
-Repositories for Fedora, openSUSE Tumbleweed and Ubuntu 15.04 were dropped. If 
-you use Fedora, use the tar archive with your own LAMP stack. openSUSE 
+Repositories for Fedora, openSUSE Tumbleweed and Ubuntu 15.04 were dropped. 
+If you use Fedora, use the tar archive with your own LAMP stack. openSUSE 
 users can rely on LEAP packages for Tumbleweed.
 
 Follow the instructions on the download page to install ownCloud. Then run the 

--- a/admin_manual/installation/linux_installation.rst
+++ b/admin_manual/installation/linux_installation.rst
@@ -14,13 +14,15 @@ Changes in the Linux Distribution Packages 9
 --------------------------------------------
 
 Linux distribution packages (from `Open Build Service`_) have been divided into 
-multiple packages for ownCloud 9: ``owncloud``, ``owncloud-deps`` and ``owncloud-files``. 
+multiple packages: ``owncloud``, ``owncloud-deps`` and ``owncloud-files``. 
 
+- **owncloud-files (recommended):** This package installs only ownCloud. It does not install *Apache*, *a database*, or any *PHP dependencies*. 
 - **owncloud:** This package installs ownCloud, complete with all dependencies.
-- **owncloud-files:** This package installs only ownCloud. It does not install *Apache*, *a database*, or any *PHP dependencies*. 
 - **owncloud-deps:** This packages install only ownCloud's dependencies (*Apache*, *PHP*, and *MySQL*). It is not intended to be installed by itself, but rather is pulled in by the ``owncloud`` metapackage. 
 
-``owncloud-files`` is available for the following distributions, but not ``owncloud-deps``.
+.. note:: The ``owncloud`` package is a meta-package that only installs ownCloud’s dependencies, such as Apache, and the required PHP modules. We don't recommend it, as it can be harmful, such as in environments where several applications are hosted simultaneously. As such we recommend using ``owncloud-files`` (which actually installs ownCloud) and further recommend administrators manage both the environment as well as `ownCloud's dependencies <https://doc.owncloud.org/server/10.0/admin_manual/installation/source_installation.html>`_.
+
+.. note:: ``owncloud-files`` is available for the following distributions, but not ``owncloud-deps``.
 
 You will have to install your own LAMP stack first. This 
 allows you to create your own custom LAMP stack without dependency conflicts 

--- a/admin_manual/installation/linux_installation.rst
+++ b/admin_manual/installation/linux_installation.rst
@@ -3,27 +3,70 @@ Preferred Installation Method
 =============================
 
 For production environments, we recommend the installation from the tar archive. 
-This applies in particular to scenarios, where the web server, storage and database are on separate machines. 
+This applies in particular to scenarios, where the Web server, storage and database are on separate machines. 
+In this constellation, all dependencies and requirements are managed by the package management 
+of your operating system, while the ownCloud code itself is maintained in a sequence of simple steps 
+as documented in our instructions for the :doc:`Manual Installation on Linux <source_installation>` and the :doc:`Manual ownCloud Upgrade <../maintenance/manual_upgrade>`.
 
-In this constellation, all dependencies and requirements are managed by your operating system's package manager, while the ownCloud code itself is maintained in a sequence of simple steps as documented in our instructions for the :doc:`Manual Installation on Linux <source_installation>` and the :doc:`Manual ownCloud Upgrade <../maintenance/manual_upgrade>`.
 The package installation is for single-server setups only.
 
+Changes in the Linux Distribution Packages 9
+--------------------------------------------
+
+Linux distribution packages (from `Open Build Service`_) have been divided into 
+multiple packages for ownCloud 9: ``owncloud``, ``owncloud-deps`` and ``owncloud-files``. 
+
+- **owncloud:** This package installs ownCloud, complete with all dependencies.
+- **owncloud-files:** This package installs only ownCloud. It does not install *Apache*, *a database*, or any *PHP dependencies*. 
+- **owncloud-deps:** This packages install only ownCloud's dependencies (*Apache*, *PHP*, and *MySQL*). It is not intended to be installed by itself, but rather is pulled in by the ``owncloud`` metapackage. 
+
+``owncloud-files`` is available for the following distributions, but not ``owncloud-deps``.
+
+You will have to install your own LAMP stack first. This 
+allows you to create your own custom LAMP stack without dependency conflicts 
+with the ownCloud package. Browse 
+`<http://download.owncloud.org/download/repositories/9.1/owncloud/>`_ to find 
+the ``owncloud-files`` package for your distro:
+
+* Ubuntu 14.04, 16.04
+* Debian 7, 8
+* RHEL 6, 7
+* CentOS 6 SCL, 7
+* SLES 12, 12 SP1
+* openSUSE 13.2, Leap 42.1
+
+ownCloud packages with dependencies are available for the following Linux distributions:
+
+* Ubuntu 14.04, 16.04
+* Debian 8
+* RHEL 7
+* CentOS 7
+* SLES 12
+* openSUSE 13.2, Leap 42.1
+
+Repositories for Fedora, openSUSE Tumbleweed and Ubuntu 15.04 were dropped. If 
+you use Fedora, use the tar archive with your own LAMP stack. openSUSE 
+users can rely on LEAP packages for Tumbleweed.
+
+Follow the instructions on the download page to install ownCloud. Then run the 
+Installation Wizard to complete your installation. (see 
+:doc:`installation_wizard`).
+
+.. warning:: Do not move the folders provided by these packages after the 
+   installation, as this will break updates.
+
+See the :doc:`system_requirements` for the recommended ownCloud setup and 
+supported platforms.
+
 Repositories
-------------
+~~~~~~~~~~~~
 
-You may use either of the following repositories for ownCloud 9.1:
+You may use either of the following repositories for ownCloud, substituting ``<version>`` for the version of ownCloud that you want to install, or ``stable``:
 
-* `<https://download.owncloud.org/download/repositories/stable/owncloud/>`_
-* `<https://download.owncloud.org/download/repositories/9.1/owncloud/>`_
+* ``https://download.owncloud.org/download/repositories/<version>/owncloud/``
 
-When you use the Stable repo, you never have to change it as it always tracks 
-the current stable ownCloud version through all major releases: 8.2, 9.0, 
-and so on. (Major releases are indicated by the second number, so 8.0, 8.1, 
-8.2, and 9.0 were all major releases.)
-
-If you wish to track a specific major release, such as 9.0 or 9.1, then use 
-that repo. That way you won't accidentally find yourself looking at an upgrade 
-to the next major release before you're ready.
+- If you use ``stable``, you never have to change it, as it always tracks the current stable ownCloud version through all major releases. Major releases are indicated by the second number, so 8.0, 8.1, 8.2, and 9.0 were all major releases.
+- If you wish to track a specific major release, such as 9.0 or 9.1, then substitute ``<version>`` with that instead. Doing so avoids you accidentally upgrading to the next major release before you're ready.
 
 Installing ownCloud Enterprise Edition
 --------------------------------------

--- a/admin_manual/release_notes.rst
+++ b/admin_manual/release_notes.rst
@@ -244,53 +244,6 @@ See :doc:`installation/linux_installation`.
 New option for the ownCloud admin to enable or disable sharing on individual external mountpoints
 (see :ref:`external_storage_mount_options_label`). Sharing on such mountpoints is disabled by default.
 
-Installation
-~~~~~~~~~~~~
-
-Linux distribution packages (from `Open Build Service`_) have been divided into multiple packages for ownCloud 9: ``owncloud``, ``owncloud-deps`` and ``owncloud-files``. 
-
-Install the metapackage ``owncloud`` to get a complete installation with all dependencies.
-The ``owncloud-files`` package installs only ownCloud, without Apache, database, or PHP dependencies. 
-
-The ``owncloud-deps`` packages install all dependencies: Apache, PHP, and MySQL. 
-``owncloud-deps`` is not intended to be installed by itself, but rather is pulled in by the metapackage ``owncloud``. 
-
-``owncloud-files`` is available for the following distributions, but not ``owncloud-deps``.
-
-You will have to install your own LAMP stack first. 
-This allows you to create your own custom LAMP stack without dependency conflicts with the ownCloud package. 
-Browse `<http://download.owncloud.org/download/repositories/9.1/owncloud/>`_ to find the ``owncloud-files`` package for your distro:
-
-* Ubuntu 14.04, 16.04
-* Debian 7, 8
-* RHEL 6, 7
-* CentOS 6 SCL, 7
-* SLES 12, 12 SP1
-* openSUSE 13.2, Leap 42.1
-
-ownCloud packages with dependencies are available for the following Linux distributions:
-
-* Ubuntu 14.04, 16.04
-* Debian 8
-* RHEL 7
-* CentOS 7
-* SLES 12
-* openSUSE 13.2, Leap 42.1
-
-Repositories for Fedora, openSUSE Tumbleweed and Ubuntu 15.04 were dropped. If 
-you use Fedora, use the tar archive with your own LAMP stack. openSUSE 
-users can rely on LEAP packages for Tumbleweed.
-
-Follow the instructions on the download page to install ownCloud. Then run the 
-Installation Wizard to complete your installation. (see 
-:doc:`installation/installation_wizard`).
-
-.. warning:: Do not move the folders provided by these packages after the 
-   installation, as this will break updates.
-
-See the :doc:`installation/system_requirements` for the recommended ownCloud setup and 
-supported platforms.
-
 Enterprise 9.0
 ~~~~~~~~~~~~~~
 


### PR DESCRIPTION
This reverts commit b50b6655757721ee22faaae7ad2eaf746513769c.
It adds the details about the different ownCloud packages back in, yet removes references to version 9. Now, they're applicable to all installations (to which they're relevant). This fixes #3210.