### PR TITLE
Attempt to correct the latexpdf build error in Jenkins

### DIFF
--- a/admin_manual/conf.py
+++ b/admin_manual/conf.py
@@ -171,9 +171,7 @@ htmlhelp_basename = 'ownCloudServerAdminManual'
 
 # -- Options for LaTeX output --------------------------------------------------
 
-latex_elements = {'preamble': '\usepackage{morefloats}', 'figure_align': 'H',
-}
-
+latex_elements = {
 # latex_elements = {
 # The paper size ('letterpaper' or 'a4paper').
 #'papersize': 'letterpaper',
@@ -182,10 +180,21 @@ latex_elements = {'preamble': '\usepackage{morefloats}', 'figure_align': 'H',
 #'pointsize': '10pt',
 
 # Additional stuff for the LaTeX preamble.
+#'preamble': '\usepackage{morefloats}', 'figure_align': 'H',
+'preamble': "".join((
+    '\DeclareUnicodeCharacter{00A0}{ }',  # NO-BREAK SPACE
+    '\DeclareUnicodeCharacter{251C}{+}',  # BOX DRAWINGS LIGHT VERTICAL AND RIGHT
+    '\DeclareUnicodeCharacter{2514}{+}',  # BOX DRAWINGS LIGHT UP AND RIGHT
+)),
+}
+
+# Additional stuff for the LaTeX preamble.
 
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title, author, documentclass [howto/manual]).
-latex_documents = [('contents', 'ownCloud_Server_Administration_Manual.tex', u'ownCloud Server Administration Manual', u'The ownCloud developers', 'manual'),]
+latex_documents = [
+  ('contents', 'ownCloud_Server_Administration_Manual.tex', u'ownCloud Server Administration Manual', 
+   u'The ownCloud developers', 'manual'),]
 
 # The name of an image file (relative to this directory) to place at the top of
 # the title page.
@@ -209,13 +218,15 @@ latex_logo = '../_shared_assets/static/logo-blue.pdf'
 
 # -- Options for pdf page output -----------------------------------------------
 
-pdf_documents = [('contents', u'owncloud Server Administration Manual', u'ownCloud Server Administration Manual', u'The ownCloud developers'),]
+pdf_documents = [('contents', u'owncloud Server Administration Manual', 
+                  u'ownCloud Server Administration Manual', u'The ownCloud developers'),]
 
 # -- Options for manual page output --------------------------------------------
 
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
-man_pages = [ ('contents', 'owncloudserveradminmanual', u'ownCloud Server Administration Manual', [u'The ownCloud developers'], 1) ]
+man_pages = [ ('contents', 'owncloudserveradminmanual', u'ownCloud Server Administration Manual', 
+               [u'The ownCloud developers'], 1) ]
 
 # If true, show URL addresses after external links.
 #man_show_urls = False
@@ -226,7 +237,9 @@ man_pages = [ ('contents', 'owncloudserveradminmanual', u'ownCloud Server Admini
 # Grouping the document tree into Texinfo files. List of tuples
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
-texinfo_documents = [ ('contents', 'ownCloud Server Admin Manual', u'ownCloud Server Administration Manual', u'The ownCloud developers', 'ownCloud', 'The ownCloud Server Administration Manual.', 'Miscellaneous'), ]
+texinfo_documents = [ ('contents', 'ownCloud Server Admin Manual', u'ownCloud Server Administration Manual', 
+                       u'The ownCloud developers', 'ownCloud', 'The ownCloud Server Administration Manual.', 
+                       'Miscellaneous'), ]
 
 # Documents to append as an appendix to all manuals.
 #texinfo_appendices = []

--- a/developer_manual/conf.py
+++ b/developer_manual/conf.py
@@ -180,6 +180,11 @@ latex_elements = {
 
 # Additional stuff for the LaTeX preamble.
 #'preamble': '',
+'preamble': "".join((
+    '\DeclareUnicodeCharacter{00A0}{ }',  # NO-BREAK SPACE
+    '\DeclareUnicodeCharacter{251C}{+}',  # BOX DRAWINGS LIGHT VERTICAL AND RIGHT
+    '\DeclareUnicodeCharacter{2514}{+}',  # BOX DRAWINGS LIGHT UP AND RIGHT
+)),
 }
 
 # Grouping the document tree into LaTeX files. List of tuples

--- a/user_manual/conf.py
+++ b/user_manual/conf.py
@@ -180,6 +180,11 @@ latex_elements = {
 
 # Additional stuff for the LaTeX preamble.
 #'preamble': '',
+'preamble': "".join((
+    '\DeclareUnicodeCharacter{00A0}{ }',  # NO-BREAK SPACE
+    '\DeclareUnicodeCharacter{251C}{+}',  # BOX DRAWINGS LIGHT VERTICAL AND RIGHT
+    '\DeclareUnicodeCharacter{2514}{+}',  # BOX DRAWINGS LIGHT UP AND RIGHT
+)),
 }
 
 # Grouping the document tree into LaTeX files. List of tuples


### PR DESCRIPTION
The documentation build's been failing for some time now. This PR attempts to adjust the Sphinx-Doc configuration options to fix it, according to advice found in [this GitHub issue comment](https://github.com/rtfd/readthedocs.org/issues/416#issuecomment-61596994). The pertinent sections of the error notification email are below.

```
Underfull \vbox (badness 10000) detected at line 10862
[153] [154]
Underfull \hbox (badness 7722) in paragraph at lines 10895--10898
\T1/pcr/m/n/10 print_unescaped($l->t('This is some text'));?> \T1/ptm/m/n/10 Fo
r the right date for-mat use \T1/pcr/m/n/10 <?php
[155] [156]
Underfull \hbox (badness 10000) in paragraph at lines 11101--11102
[]\T1/ptm/m/n/10 To run test for a spe-cific app with the pro-vided PH-PUnit ve
r-sion,

Underfull \hbox (badness 10000) in paragraph at lines 11101--11102
\T1/ptm/m/n/10 change into \T1/pcr/m/n/10 <webroot>/apps/<appnname>/<testfolder
\T1/ptm/m/n/10 and call
[157] [158] [159] [160]
Underfull \hbox (badness 10000) in paragraph at lines 11441--11442
[]\T1/ptm/m/n/10 If you don't have a web-server al-ready run-ning, leave SRV_HO
ST_URL empty ( \T1/pcr/m/n/10 export
[161] [162]

! Package inputenc Error: Unicode char ��� (U+251C)
(inputenc)                not set up for use with LaTeX.

See the inputenc package documentation for explanation.
Type  H <return>  for immediate help.
...                                              

l.11546 ���-- integration

? Build timed out (after 120 minutes). Marking the build as failed.
```