### PR TITLE
Use the broader 10.0 version number in the docs

### DIFF
--- a/admin_manual/conf.py
+++ b/admin_manual/conf.py
@@ -44,9 +44,9 @@ master_doc = 'contents'
 # built documents.
 #
 # The short X.Y version.
-version = '10.0.1'
+version = '10.0'
 # The full version, including alpha/beta/rc tags.
-release = '10.0.1'
+release = '10.0'
 
 # General information about the project.
 project = u'ownCloud %s Server Administration Manual' % (version)


### PR DESCRIPTION
The current version number in the docs and doc index was set to 10.0.1, which is outdated. It's now being reverted to 10.0, also to keep in sync with the previous standard. This fixes #3236.