### PR TITLE
Fix Assign a Tag to a File

### DIFF
--- a/developer_manual/webdav_api/tags.rst
+++ b/developer_manual/webdav_api/tags.rst
@@ -337,7 +337,7 @@ Assign a Tag to a File
 ================================================================ ====== ================
 Request Path                                                     Method Content Type
 ================================================================ ====== ================
-``remote.php/dav/systemtags-relations/files/<tagid>/<fileid>``   PUT    ``text/xml``
+``remote.php/dav/systemtags-relations/files/<fileid>/<tagid>``   PUT    ``text/xml``
 ================================================================ ====== ================
 
 To assign a tag to a file, send an authenticated ``PUT`` request specifying the path to the file to tag.


### PR DESCRIPTION
The order of fileid and tagid was incorrect.
Reported in https://github.com/owncloud/core/issues/28567