### PR TITLE
Document market app installation and upgrade

### DIFF
--- a/admin_manual/configuration/server/occ_command.rst
+++ b/admin_manual/configuration/server/occ_command.rst
@@ -1090,6 +1090,10 @@ The ``market`` commands *install*, *list*, and *upgrade* applications from `the 
     market:list       Lists apps as available on the marketplace.
     market:upgrade    Installs new app versions if available on the marketplace
 
+.. note::
+   The user running the update command, which will likely be your webserver user, needs write permission for the ``/apps`` folder. 
+   If they don’t have write permission, the command may report that the update was successful, but it may silently fail.
+
 .. _reports_commands_label:
    
 Reports

--- a/admin_manual/configuration/server/occ_command.rst
+++ b/admin_manual/configuration/server/occ_command.rst
@@ -33,6 +33,7 @@ occ Command Directory
 * :ref:`ldap_commands_label`
 * :ref:`logging_commands_label`
 * :ref:`maintenance_commands_label`
+* :ref:`market_commands_label`
 * :ref:`reports_commands_label`
 * :ref:`security_commands_label`
 * :ref:`shibboleth_label`
@@ -1074,6 +1075,21 @@ command after modifying ``config/mimetypemapping.json``. If you change a
 mimetype, run ``maintenance:mimetype:update-db --repair-filecache`` to apply the 
 change to existing files.
 
+.. _market_commands_label:
+   
+Market
+------
+
+The ``market`` commands *install*, *list*, and *upgrade* applications from `the ownCloud Marketplace`.
+
+.. code-block:: console
+   
+  market
+    market:install    Install apps from the marketplace. If already installed and 
+                      an update is available the update will be installed.
+    market:list       Lists apps as available on the marketplace.
+    market:upgrade    Installs new app versions if available on the marketplace
+
 .. _reports_commands_label:
    
 Reports
@@ -1745,3 +1761,4 @@ json    This will render the output as a JSON-encoded, but not formatted, string
 .. links
    
 .. _one of the commands: :ref:`Available Background Jobs`
+.. _the ownCloud Marketplace: https://marketplace.owncloud.com/

--- a/admin_manual/upgrading/index.rst
+++ b/admin_manual/upgrading/index.rst
@@ -6,3 +6,4 @@ Upgrading
    :maxdepth: 2
    
    upgrade_php
+   marketplace_apps

--- a/admin_manual/upgrading/marketplace_apps.rst
+++ b/admin_manual/upgrading/marketplace_apps.rst
@@ -1,0 +1,34 @@
+================================
+Upgrade Marketplace Applications
+================================
+
+To upgrade Marketplace applications, please refer to the documentation below, as applicable for your ownCloud setup.
+
+Single-Server Environment
+-------------------------
+
+To upgrade Marketplace applications when running ownCloud in a single server environment, you can use use the :ref:`Market app <apps_commands_label>`, specifically by running ``market:upgrade``.
+This will install new versions of your installed apps if updates are available in the marketplace.
+
+.. note::
+   The user running the update command, which will likely be your webserver user, needs write permission for the ``/apps`` folder. 
+   If they don’t have write permission, the command may report that the update was successful, however it may silently fail.
+
+Clustered/Multi-Server Environment
+----------------------------------
+
+The :ref:`Market app <market_commands_label>`, both the UI and command line, are not, *currently*, designed to operate on clustered installations.
+Given that, you will have to update the applications on each server in the cluster individually. 
+There are several ways to do this.
+But here is a concise approach:
+
+#. Download the latest server release (whether `the tarball`_ or `the zip archive`_).
+#. Download your installed apps from `the ownCloud marketplace`.
+#. Combine them together into one installation source, such as *a Docker or VM image*, or *an Ansible script*, etc.
+#. Apply the combined upgrade across all the cluster nodes in your ownCloud setup.
+
+.. Links
+   
+.. _the tarball: https://download.owncloud.org/community/owncloud-10.0.2.tar.bz2
+.. _the zip archive: https://download.owncloud.org/community/owncloud-10.0.2.zip
+.. _the ownCloud marketplace: https://marketplace.owncloud.com/


### PR DESCRIPTION
This PR adds documentation for how to upgrade Market apps, both on a single server ownCloud installation, as well as on multi-server installations.

### Relates To

https://github.com/owncloud/enterprise/issues/2082