### PR TITLE
Be specific that PHP 7.0 is the highest supported PHP version for ownCloud

### DIFF
--- a/admin_manual/installation/system_requirements.rst
+++ b/admin_manual/installation/system_requirements.rst
@@ -17,7 +17,7 @@ Operating System  Ubuntu 16.04, Debian 7 and 8, SUSE Linux Enterprise Server 12
                   and 12 SP1, Red Hat Enterprise Linux/Centos 6.5 and 7 
 Database          MySQL or MariaDB 5.5+, Oracle 11g, PostgreSQL, & SQLite
 Web server        Apache 2.4 with mod_php
-PHP Runtime       PHP (5.6+ or 7.0+)
+PHP Runtime       PHP (5.6 or 7.0)
 ================= =============================================================
 
 .. note::


### PR DESCRIPTION
Thanks to @michaelstingl for calling out this one.

### Relates To

https://github.com/owncloud/enterprise/issues/1960.