### PR TITLE
Be specific that PHP 7.0 is the highest supported version for ownCloud

### DIFF
--- a/admin_manual/installation/system_requirements.rst
+++ b/admin_manual/installation/system_requirements.rst
@@ -26,7 +26,7 @@ Platform          Options
 Operating System  Ubuntu 16.04
 Database          MySQL or MariaDB 5.5+
 Web server        Apache 2.4 with mod_php
-PHP Runtime       PHP (5.6+ or 7.0+)
+PHP Runtime       PHP (5.6 or 7.0)
 ================= =============================================================
 
 Supported Platforms


### PR DESCRIPTION
This relates to https://github.com/owncloud/enterprise/issues/1960.