### PR TITLE
Remove empty webdav link in the User manual

### DIFF
--- a/user_manual/contents.rst
+++ b/user_manual/contents.rst
@@ -12,7 +12,6 @@ Table of Contents
     pim/index
     external_storage/index
     files/index
-    webdav-api/index
     session_management
     webinterface
     userpreferences

--- a/user_manual/webdav-api/index.rst
+++ b/user_manual/webdav-api/index.rst
@@ -1,9 +1,0 @@
-===========
-WebDAV APIs
-===========
-
-.. toctree::
-   :maxdepth: 1
-
-   tags/index
-


### PR DESCRIPTION
This PR:

- Removes the empty WebDAV API folder from the user manual
- Removes the table of contents entry which pointed to it

### Relates To

#3273