### PR TITLE
Change location of Firewall settings panel

### DIFF
--- a/admin_manual/enterprise/firewall/file_firewall.rst
+++ b/admin_manual/enterprise/firewall/file_firewall.rst
@@ -3,7 +3,7 @@ File Firewall
 =============
 
 The File Firewall GUI enables you to create and manage firewall rule sets from 
-your ownCloud admin page, Security section. The File Firewall gives you finer-grained control of 
+your ownCloud admin page's Security section. The File Firewall gives you finer-grained control of 
 access and sharing, with rules for allowing or denying access, and restrictions 
 per group, upload size, client devices, IP address, time of day, and many more 
 criteria. For additional flexibility the File Firewall also supports regular 

--- a/admin_manual/enterprise/firewall/file_firewall.rst
+++ b/admin_manual/enterprise/firewall/file_firewall.rst
@@ -3,7 +3,7 @@ File Firewall
 =============
 
 The File Firewall GUI enables you to create and manage firewall rule sets from 
-your ownCloud admin page. The File Firewall gives you finer-grained control of 
+your ownCloud admin page, Security section. The File Firewall gives you finer-grained control of 
 access and sharing, with rules for allowing or denying access, and restrictions 
 per group, upload size, client devices, IP address, time of day, and many more 
 criteria. For additional flexibility the File Firewall also supports regular 


### PR DESCRIPTION
PR https://github.com/owncloud/firewall/pull/391 for issue https://github.com/owncloud/firewall/issues/273 moves the firewall settings panel into the Security section (where it will appear with password_policy and whatever other security apps are enabled).