### PR TITLE
Remove documentation showing how to setup your own appstore

### DIFF
--- a/admin_manual/installation/apps_management_installation.rst
+++ b/admin_manual/installation/apps_management_installation.rst
@@ -70,25 +70,3 @@ The key **url** defines the HTTP web path to that folder, starting at the ownClo
                 "writable" => true,
         ),
     ),
-
-Using Your Own Appstore
------------------------
-
-You can enable the installation of apps from your own apps store. 
-This requires that you can write to at least one of the configured apps directories.
-
-To enable installation from your own apps store:
-
-1. Set the ``appstoreenabled`` parameter to "true".
-   This parameter is used to enable your apps store in ownCloud.
-
-2. Set the ``appstoreurl`` to the URL of your ownCloud apps store.
-   This parameter is used to set the HTTP path to the ownCloud apps store. 
-   The appstore server must use :abbr:`OCS (Open Collaboration Services)`.
-
-.. code-block:: php
-
- <?php
-   
-   "appstoreenabled" => true,
-   "appstoreurl" => "https://api.owncloud.com/v1",


### PR DESCRIPTION
This is being done based on the description in #3120.