### PR TITLE
Fix incomplete reference to templates

### DIFF
--- a/developer_manual/general/security.rst
+++ b/developer_manual/general/security.rst
@@ -31,7 +31,7 @@ Clickjacking
 
 To prevent such attacks ownCloud sends the `X-Frame-Options` header to all template responses. Don't remove this header if you don't really need it!
 
-This is already built into ownCloud if :php:class:`OC_Template`.
+This is already built into ownCloud if `ownCloud templates <https://doc.owncloud.org/server/latest/developer_manual/app/templates.html>`_ or `Twig Templates`_ are used.
 
 Code executions / File inclusions
 ---------------------------------
@@ -247,3 +247,7 @@ Always validate the URL before redirecting if the requested URL is on the same d
 Getting help
 ------------
 If you need help to ensure that a function is secure please ask on our `mailing list <https://mailman.owncloud.org/mailman/listinfo/devel>`_ or on our IRC channel **#owncloud-dev** on **irc.freenode.net**.
+
+.. Links
+   
+.. _Twig Templates: https://twig.symfony.com/


### PR DESCRIPTION
This PR fixes a minor grammatical issue spotted by @voroyam. The sentence was broken during an earlier reorganisation of the security documentation. Secondly, I've not been able to find any reference to a `:php:class:` directive for ReStructuredText. Given that, I instead linked to the documentation of ownCloud templates instead. 