### PR TITLE
Identify the commands which aren't available in maintenance mode

### DIFF
--- a/admin_manual/configuration/server/occ_command.rst
+++ b/admin_manual/configuration/server/occ_command.rst
@@ -394,6 +394,9 @@ migrate address books from 8.2 when you upgrade to 9.0::
   dav:sync-system-addressbook   Synchronizes users to the system 
                                 address book
                                       
+.. note::
+  These commands are not available in :ref:`single-user (maintenance) mode <maintenance_commands_label>`.
+
 The syntax for ``dav:create-addressbook`` and  ``dav:create-calendar`` is 
 ``dav:create-addressbook [user] [name]``. This example creates the addressbook 
 ``mollybook`` for the user molly::
@@ -551,10 +554,6 @@ See :doc:`../../configuration/files/encryption_configuration` to learn more.
 Federation Sync
 ---------------
 
-.. note::
-  This command is only available when the "Federation" app (``federation``) is
-  enabled.
- 
 Synchronize the address books of all federated ownCloud servers::
 
  federation:sync-addressbooks  Synchronizes address books of all 
@@ -566,7 +565,8 @@ to synchronize federated servers::
 
   sudo -u www-data php occ federation:sync-addressbooks
   
-Added in 9.0.  
+.. note::
+  This command is only available when the "Federation" app (``federation``) is enabled.
 
 .. _file_operations_label:
 
@@ -581,6 +581,9 @@ File Operations
   files:transfer-ownership   All files and folders are moved to another 
                              user - shares are moved as well. (Added in 9.0)
  
+.. note::
+  These commands are not available in :ref:`single-user (maintenance) mode <maintenance_commands_label>`.
+
 The ``files:scan`` command scans for new files and updates the file cache. You 
 may rescan all files, per-user, a space-delimited list of users, and limit the 
 search path. If not using ``--quiet``, statistics will be shown at the end of 
@@ -660,11 +663,6 @@ Files External
 
 These commands replace the ``data/mount.json`` configuration file used in 
 ownCloud releases before 9.0.
-
-.. note::
-  These commands are only available when the "External storage support" app
-  (``files_external``) is enabled.
-
 Commands for managing external storage::
 
  files_external
@@ -689,7 +687,10 @@ ownCloud user.
 Use ``files_external:import [filename]`` to import legacy JSON configurations, 
 and to copy external mount configurations to another ownCloud server.
 
-Added in 9.0.
+.. note::
+  These commands are only available when the "External storage support" app
+  (``files_external``) is enabled.
+  It is not available in :ref:`single-user (maintenance) mode <maintenance_commands_label>`.
 
 .. _group_commands_label:
 
@@ -1115,6 +1116,9 @@ The ``market`` commands *install*, *list*, and *upgrade* applications from `the 
    The user running the update command, which will likely be your webserver user, needs write permission for the ``/apps`` folder. 
    If they don’t have write permission, the command may report that the update was successful, but it may silently fail.
 
+.. note::
+  These commands are not available in :ref:`single-user (maintenance) mode <maintenance_commands_label>`.
+
 .. _reports_commands_label:
    
 Reports
@@ -1143,6 +1147,9 @@ Alternatively, you could generate the report and email it all in one command, by
   sudo -u www-data occ configreport:generate | mail -s "configuration report" \ 
       -r <the email address to send from> \
       support@owncloud.com
+
+.. note::
+  These commands are not available in :ref:`single-user (maintenance) mode <maintenance_commands_label>`.
 
 .. _security_commands_label:
 
@@ -1191,19 +1198,22 @@ So, to cleanup all orphaned remote storages, run it as follows::
 
 You can also set it up to run as :ref:`a background job <background-jobs-header>`
 
+.. note::
+  These commands are not available in :ref:`single-user (maintenance) mode <maintenance_commands_label>`.
+
 .. _shibboleth_label:
 
 Shibboleth Modes (Enterprise Edition only)
 ------------------------------------------
 
-.. note::
-  This command is only available when the "Shibboleth user backend" app
-  (``user_shibboleth``) is enabled.
-
 ``shibboleth:mode`` sets your Shibboleth mode to ``notactive``, 
 ``autoprovision``, or ``ssoonly``::
 
  shibboleth:mode [mode]
+
+.. note::
+  These commands are only available when the "Shibboleth user backend" app
+  (``user_shibboleth``) is enabled.
 
 .. _trashbin_label: 
 
@@ -1211,8 +1221,9 @@ Trashbin
 --------
 
 .. note::
-  This command is only available when the "Deleted files" app
+  These commands are only available when the "Deleted files" app
   (``files_trashbin``) is enabled.
+  These commands are not available in :ref:`single-user (maintenance) mode <maintenance_commands_label>`.
  
 ::
 
@@ -1508,10 +1519,6 @@ Shibboleth
 Versions
 --------
 
-.. note::
-  This command is only available when the "Versions" app (``files_versions``) is
-  enabled.
-
 ::
 
  versions
@@ -1538,6 +1545,11 @@ You can delete versions for specific users in a space-delimited list::
  
 ``versions:expire`` Deletes only expired files according to the ``versions_retention_obligation`` setting in ``config.php`` (see the File versions section in :doc:`config_sample_php_parameters`). The default is to delete expired files for all users, or you may list users in a space-delimited list.
  
+.. note::
+  These commands are only available when the "Versions" app (``files_versions``) is
+  enabled.
+  These commands are not available in :ref:`single-user (maintenance) mode <maintenance_commands_label>`.
+
 .. _command_line_installation_label: 
  
 Command Line Installation


### PR DESCRIPTION
This PR:

Highlights which occ commands are not available when ownCloud is in maintenance mode. It may not seem as relevant for more experienced users. But for newcomers, it can be quite handy. 

### Fixes 

#3345