### PR TITLE
Add documentation for new External Site "target" option

### DIFF
--- a/admin_manual/configuration/server/external_sites.rst
+++ b/admin_manual/configuration/server/external_sites.rst
@@ -64,6 +64,6 @@ selecting "Inside OwnCloud Frame' (the default).
 
  - '_self': Opens link inside the ownCloud iframe (default)
  - '_top': Replaces current ownCloud window with the link
- - '_blank': Opens link in a new window'
+ - '_blank': Opens link in a new window
 
 

--- a/admin_manual/configuration/server/external_sites.rst
+++ b/admin_manual/configuration/server/external_sites.rst
@@ -55,5 +55,9 @@ On this page, X-Frame-Options prevents the embedding.
 
 .. figure:: ../../images/external-sites-5.png
 
-There isn't much you can do about these issues, but if you're curious you can 
-see what is happening.
+You may use the "Site Target" dropdown to select how the external site opens.  
+For sites that block iframing with `X-Frame-Options`, you need to select either 
+"New Window" or "Replace Current Window" as the target in order to open them.
+
+For sites that allow iframing, you may open them inside the OwnCloud UI by 
+selecting "Inside OwnCloud Frame' (the default).

--- a/admin_manual/configuration/server/external_sites.rst
+++ b/admin_manual/configuration/server/external_sites.rst
@@ -61,3 +61,9 @@ For sites that block iframing with `X-Frame-Options`, you need to select either
 
 For sites that allow iframing, you may open them inside the OwnCloud UI by 
 selecting "Inside OwnCloud Frame' (the default).
+
+ - '_self': Opens link inside the ownCloud iframe (default)
+ - '_top': Replaces current ownCloud window with the link
+ - '_blank': Opens link in a new window'
+
+


### PR DESCRIPTION
We added a new option Site Target which allows you to specify where the link to an External Site opens:

The valid target options are:
 - `_self`: Opens link inside the ownCloud iframe (default)
 - `_top`: Replaces current ownCloud window with the link
 - `_blank`: Opens link in a new window

This PR is documentation for this code change: https://github.com/owncloud/apps/pull/2221