### PR TITLE
typo fix at security routes options

### DIFF
--- a/admin_manual/configuration/server/occ_command.rst
+++ b/admin_manual/configuration/server/occ_command.rst
@@ -1238,7 +1238,7 @@ Options:
 
 ::
 
-  --output	  Output format (plain, json or json_pretty, default is plain)
+  --output	  Output format (plain, json or json-pretty, default is plain)
   --with-details  Adds more details to the output
 
 Example 1:
@@ -1263,7 +1263,7 @@ Example 2:
 
 ::
 
-  sudo  -uwww-data ./occ security:routes --output=json_pretty
+  sudo  -uwww-data ./occ security:routes --output=json-pretty
 
 ::
 


### PR DESCRIPTION
Small typo fix for security:routes options
``json_pretty`` --> ``json-pretty``
Related to https://github.com/owncloud/documentation/pull/3380
@settermjd 