### PR TITLE
Fix the admin manual version number update

### DIFF
--- a/admin_manual/conf.py
+++ b/admin_manual/conf.py
@@ -48,9 +48,9 @@ master_doc = 'contents'
 # built documents.
 #
 # The short X.Y version.
-version = '10.3'
+version = '10.0.3'
 # The full version, including alpha/beta/rc tags.
-release = '10.3'
+release = '10.0.3'
 
 # General information about the project.
 project = u'ownCloud %s Server Administration Manual' % (version)


### PR DESCRIPTION
This PR fixes an incorrect version change of the admin manual. It was incorrectly changed to `10.3` instead of `10.0.3`.

:information_desk_person: This issue was well spotted by @phil-davis, in https://github.com/owncloud/documentation/pull/3393#pullrequestreview-63966568.