### PR TITLE
Remove duplicate Market content in OCC commands documentation

### DIFF
--- a/admin_manual/configuration/server/occ_command.rst
+++ b/admin_manual/configuration/server/occ_command.rst
@@ -1152,28 +1152,6 @@ If you change a mimetype, run ``maintenance:mimetype:update-db --repair-filecach
 Market
 ------
 
-The ``market`` commands *install*, *list*, and *upgrade* applications from `the ownCloud Marketplace`_.
-
-.. code-block:: console
-   
-  market
-    market:install    Install apps from the marketplace. If already installed and 
-                      an update is available the update will be installed.
-    market:list       Lists apps as available on the marketplace.
-    market:upgrade    Installs new app versions if available on the marketplace
-
-.. note::
-   The user running the update command, which will likely be your webserver user, needs write permission for the ``/apps`` folder. 
-   If they don't have write permission, the command may report that the update was successful, but it may silently fail.
-
-.. note::
-  These commands are not available in :ref:`single-user (maintenance) mode <maintenance_commands_label>`.
-
-.. _market_commands_label:
-   
-Market
-------
-
 The ``market`` commands *install*, *list*, and *upgrade* applications from `the ownCloud Marketplace`.
 
 .. code-block:: console
@@ -1187,6 +1165,9 @@ The ``market`` commands *install*, *list*, and *upgrade* applications from `the 
 .. note::
    The user running the update command, which will likely be your webserver user, needs write permission for the ``/apps`` folder. 
    If they don’t have write permission, the command may report that the update was successful, but it may silently fail.
+
+.. note::
+   These commands are not available in :ref:`single-user (maintenance) mode <maintenance_commands_label>`.
 
 .. _reports_commands_label:
    


### PR DESCRIPTION
This PR removes duplicate Market content in the OCC commands documentation. The duplication of the content, because there was a duplication of the section label, also broke the section's TOC.

This PR fixes #3405 and fixes #3401.