### PR TITLE
Update calendar documentation

### DIFF
--- a/user_manual/pim/calendar.rst
+++ b/user_manual/pim/calendar.rst
@@ -2,19 +2,15 @@
 Using the Calendar App
 ======================
 
-The Calendar app is not enabled by default in ownCloud |version| and needs to be enabled separately. It is also not a supported core app. 
-It is currently under heavy development, so documentation has moved to the `documentation Wiki on Github 
-<https://github.com/owncloud/documentation/wiki/Using-the-Calendar-App-in- ownCloud-9.0>`_. 
-You are welcome to add content to the Wiki document; all you 
-need is a GitHub account.
-
-The default Calendar application is not able to be enabled. 
+The Calendar application is not officially supported and is not enabled by default, in ownCloud |version|. 
 If you attempt to enable it, you will see the following error:
 
 .. figure:: ../images/calendar/calendar-app-signature-could-not-get-checked-error.png
+   :alt: Error message when attempting to enable the default calendar application.
 
-To enable calendar functionality, you need to enable the Marketplace first.
-To do so, add the following line to ``config/config.php``, which connects your ownCloud instance with the Marketplace.
+To enable it, you first need to enable the Marketplace.
+To do so, add the following line to ``config/config.php``. 
+This setting connects your ownCloud instance with `the ownCloud Marketplace`_.
 
 :: 
 
@@ -30,3 +26,7 @@ After saving the changes, reload the ownCloud UI and enable the Calendar applica
 
 .. note::
    Please also check that you disable and uninstall existing apps from the old app store **before** you installing and enabling the newer versions from the marketplace. If you do not, attempting to uninstall them displays the "*app directory already exists*" error message.
+   
+.. Links
+      
+.. _the ownCloud Marketplace: https://marketplace.owncloud.com/

--- a/user_manual/pim/calendar.rst
+++ b/user_manual/pim/calendar.rst
@@ -2,11 +2,27 @@
 Using the Calendar App
 ======================
 
-The Calendar app is not enabled by default in ownCloud |version| and needs to
-be enabled separately. It is also not a supported core app. It is currently 
-under heavy development, so documentation has moved to the `documentation Wiki 
-on Github 
-<https://github.com/owncloud/documentation/wiki/Using-the-Calendar-App-in- 
-ownCloud-9.0>`_. You are welcome to add content to the Wiki document; all you 
-need is a Github account.
+The Calendar app is not enabled by default in ownCloud |version| and needs to be enabled separately. It is also not a supported core app. 
+It is currently under heavy development, so documentation has moved to the `documentation Wiki on Github 
+<https://github.com/owncloud/documentation/wiki/Using-the-Calendar-App-in- ownCloud-9.0>`_. 
+You are welcome to add content to the Wiki document; all you 
+need is a GitHub account.
 
+The default Calendar application is not able to be enabled. 
+To enable calendar functionality, you need to enable the Marketplace first.
+To do so, add the following line to ``config/config.php``, which connects your ownCloud instance with the Marketplace.
+
+:: 
+
+  'appstoreurl' => 'https://marketplace.owncloud.com/api/v0',
+
+After saving the changes, reload the ownCloud UI and enable the Calendar application.
+
+.. note:: 
+   In case you are sitting behind a firewall and cannot reach the marketplace (or if you prefer to install applications manually) you can install the Calendar app by:
+  - Downloading the package from the Marketplace
+  - Unpacking the tarball into the ``apps`` folder 
+  - Enable the Calendar app, available under disabled apps.
+
+.. note::
+   Please also check that you disable and uninstall existing apps from the old app store **before** you installing and enabling the newer versions from the marketplace. If you do not, attempting to uninstall them displays the "*app directory already exists*" error message.

--- a/user_manual/pim/calendar.rst
+++ b/user_manual/pim/calendar.rst
@@ -9,6 +9,10 @@ You are welcome to add content to the Wiki document; all you
 need is a GitHub account.
 
 The default Calendar application is not able to be enabled. 
+If you attempt to enable it, you will see the following error:
+
+.. figure:: ../images/calendar/calendar-app-signature-could-not-get-checked-error.png
+
 To enable calendar functionality, you need to enable the Marketplace first.
 To do so, add the following line to ``config/config.php``, which connects your ownCloud instance with the Marketplace.
 


### PR DESCRIPTION
This PR corrects the existing documentation for the calendar application in ownCloud 9.1. It removes reference to the GitHub wiki and shows how to install the application from the Marketplace.