### PR TITLE
Document requirement for prefork MPM when using mod_php

### DIFF
--- a/admin_manual/configuration/server/oc_server_tuning.rst
+++ b/admin_manual/configuration/server/oc_server_tuning.rst
@@ -123,12 +123,6 @@ In combination with the periodic checks of the sync client the following setting
 	KeepAliveTimeout 100
 	MaxKeepAliveRequests 200
 
-MPM
-~~~
-
-`Apache prefork`_ has to be used. 
-Don’t use threaded ``mpm`` with ``mod_php``, because PHP is currently not thread safe.
-
 Hostname Lookups
 ~~~~~~~~~~~~~~~~
 
@@ -151,4 +145,3 @@ However, keep `ErrorLog`_ set, so errors can be tracked down.
 .. _ErrorLog: https://httpd.apache.org/docs/2.4/logs.html#errorlog
 .. _KeepAlive: https://en.wikipedia.org/wiki/HTTP_persistent_connection
 .. _enable HTTP/2 support for Apache: https://httpd.apache.org/docs/2.4/howto/http2.html
-.. _Apache prefork: https://httpd.apache.org/docs/2.4/mod/prefork.html

--- a/admin_manual/installation/source_installation.rst
+++ b/admin_manual/installation/source_installation.rst
@@ -389,6 +389,14 @@ Additional Apache Configurations
 
 - If you're running ownCloud in a sub-directory and want to use CalDAV or CardDAV clients make sure you have configured the correct :ref:`service-discovery-label` URLs.
 
+.. _apache-mpm-label:
+
+Multi-Processing Module (MPM)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+`Apache prefork`_ has to be used. Don’t use a threaded ``MPM`` like ``event`` or ``worker`` with ``mod_php``,
+because PHP is currently `not thread safe`_.
+
 .. _enabling_ssl_label:
 
 Enable SSL
@@ -438,6 +446,8 @@ After you do so, your ownCloud server will be ready to use.
 
 .. _SabreDav: http://sabre.io/
 .. _to setup your ownCloud environment: https://doc.owncloud.com/server/latest/developer_manual/general/devenv.html
+.. _Apache prefork: https://httpd.apache.org/docs/2.4/mod/prefork.html
+.. _not thread safe: https://secure.php.net/manual/en/install.unix.apache2.php
 
 .. PHP Extension Links
 

--- a/admin_manual/installation/system_requirements.rst
+++ b/admin_manual/installation/system_requirements.rst
@@ -16,7 +16,7 @@ Platform          Options
 Operating System  Ubuntu 16.04, Debian 7 and 8, SUSE Linux Enterprise Server 12 
                   and 12 SP1, Red Hat Enterprise Linux/Centos 6.5 and 7 
 Database          MySQL or MariaDB 5.5+, Oracle 11g, PostgreSQL, & SQLite
-Web server        Apache 2.4 with mod_php
+Web server        Apache 2.4 with ``prefork`` :ref:`apache-mpm-label` and ``mod_php``
 PHP Runtime       PHP (5.6+, 7.0, & 7.1)
 ================= =============================================================
 

--- a/admin_manual/issues/general_troubleshooting.rst
+++ b/admin_manual/issues/general_troubleshooting.rst
@@ -142,10 +142,12 @@ Some common problems / error messages found in your logfiles as described above:
   accessing your SQLite database file in your data directory 
   (``data/owncloud.db``). Please check the permissions of this folder/file or 
   if it exists at all. If you're using MySQL please start your database.
-* ``Connection closed / Operation cancelled`` -> This could be caused by wrong 
-  ``KeepAlive`` settings within your Apache config. Make sure that 
-  ``KeepAlive`` is set to ``On`` and  also try to raise the limits of 
-  ``KeepAliveTimeout`` and  ``MaxKeepAliveRequests``.
+* ``Connection closed / Operation cancelled`` or ``expected filesize 4734206 got 458752``
+  -> This could be caused by wrong ``KeepAlive`` settings within your Apache config.
+  Make sure that ``KeepAlive`` is set to ``On`` and  also try to raise the limits of 
+  ``KeepAliveTimeout`` and  ``MaxKeepAliveRequests``. On Apache with ``mod_php`` using
+  a different :ref:`apache-mpm-label` then ``prefork`` could be another reason. Further
+  information is available at the `forums <https://central.owncloud.org/t/expected-filesize-xxx-got-yyy-0/816>`_.
 * ``No basic authentication headers were found`` -> This error is shown in your
   ``data/owncloud.log`` file. Some Apache modules like ``mod_fastcgi``, ``mod_fcgid``
   or ``mod_proxy_fcgi`` are not passing the needed authentication headers to


### PR DESCRIPTION
This is a little bit hidden in:

https://github.com/owncloud/documentation/blob/3a5289e71a70d7b53b27cadd61804db5788ba9c4/admin_manual/configuration/server/oc_server_tuning.rst#mpm

but is a hard requirement when using mod_php because that module is not thread safe.

https://secure.php.net/manual/en/install.unix.apache2.php

Debian e.g. is enforcing this worker in their libapache2-mod-php7.0.postinst script:

```
apache2_msg "err" "$DPKG_MAINTSCRIPT_PACKAGE: Could not switch to prefork MPM, not enabling PHP 7.0"
```

but there are other distros / systems where people still enable multi-threaded MPMs like seen in e.g.:

https://central.owncloud.org/t/many-operation-canceled-connection-closed-errors-during-sync/6006/7

In general using anything else then prefork (like worker or event) will cause issues like the known:

Connection closed
Operation canceled

and maybe also the "expected filesize 4734206 got 458752" messages described by some one in here:

https://central.owncloud.org/t/expected-filesize-xxx-got-yyy-0/816

*Edit*

Some more refs: https://github.com/owncloud/core/issues/22957, https://github.com/owncloud/core/issues/12193, https://github.com/owncloud/core/issues/26406, https://github.com/owncloud/core/issues/9832, https://github.com/owncloud/core/issues/9909

*Edit2*

I have also moved the MPM part from the OC Server Tuning docs. This is not really a tuning recommendation but a installation requirement. Furthermore added a few additional references to the troubleshooting guide.