### PR TITLE
Backport removal of obsolete performance link from LDAP documentation

### DIFF
--- a/admin_manual/configuration/user/user_auth_ldap.rst
+++ b/admin_manual/configuration/user/user_auth_ldap.rst
@@ -594,8 +594,6 @@ Now you can modify and enable the configuration.
 Performance tips
 ----------------
 
-See the documentation wiki for `additional LDAP tips and tricks <https://github.com/owncloud/documentation/wiki/LDAP-Tips-for-Active-Directory-and-openLDAP>`_. The following performance tips are standard for inmproving LDAP performance. 
-
 Caching
 ^^^^^^^
 


### PR DESCRIPTION
### Relates To

#3469 #3471