### PR TITLE
nginx: set fastcgi_buffering to off

### DIFF
--- a/admin_manual/installation/nginx_configuration.rst
+++ b/admin_manual/installation/nginx_configuration.rst
@@ -158,6 +158,7 @@ your NGINX installation.
           fastcgi_read_timeout 180; # increase default timeout e.g. for long running carddav/ caldav syncs with 1000+ entries
           fastcgi_pass php-handler;
           fastcgi_intercept_errors on;
+          fastcgi_buffering off;
           fastcgi_request_buffering off; #Available since NGINX 1.7.11
       }
   
@@ -314,6 +315,7 @@ The following config should be used when ownCloud is not in your webroot but pla
               fastcgi_read_timeout 180; # increase default timeout e.g. for long running carddav/ caldav syncs with 1000+ entries
               fastcgi_pass php-handler;
               fastcgi_intercept_errors on;
+              fastcgi_buffering off;
               fastcgi_request_buffering off; #Available since NGINX 1.7.11
           }
   


### PR DESCRIPTION
Fixing or workaround of core issue https://github.com/owncloud/core/issues/29328 (Big file download from SMB via fast networks eats up memory)

We have not set this parameter in nginx before but it is needed in low mem systems and fast client download situations. Should not be an issue but necessary because likely a nginx buffering problem.

Needs Backporting to 10, maybe 9

@jvillafanez @PVince81 @settermjd 