### PR TITLE
Redirect setup security warning to code configuration

### DIFF
--- a/admin_manual/configuration/server/caching_configuration.rst
+++ b/admin_manual/configuration/server/caching_configuration.rst
@@ -369,6 +369,8 @@ Use the server's IP address or hostname so that it is accessible to other hosts:
       'port' => 6379,
   ],
 
+.. _configuring_transactional_file_locking_label:
+
 Configuring Transactional File Locking
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/admin_manual/configuration/server/security_setup_warnings.rst
+++ b/admin_manual/configuration/server/security_setup_warnings.rst
@@ -36,7 +36,7 @@ Transactional file locking is disabled
 "Transactional file locking is disabled, this might lead to issues with race
 conditions."
 
-Please see :doc:`../../configuration/files/files_locking_transactional` on how
+Please see :ref:`Transactional File Locking <configuring_transactional_file_locking_label>` for how
 to correctly configure your environment for transactional file locking.
 
 You are accessing this site via HTTP


### PR DESCRIPTION
This PR redirects the link to configure transactional file locking to [the required code sample,](https://doc.owncloud.com/server/10.0/admin_manual/configuration/server/caching_configuration.html#configuring-transactional-file-locking) saving a few clicks and confusion. 

### Fixes 

#3467.