### PR TITLE
Update external storage link to 10.0

### DIFF
--- a/user_manual/external_storage/external_storage.rst
+++ b/user_manual/external_storage/external_storage.rst
@@ -6,6 +6,6 @@ The External Storage application allows you to mount external storage services,
 such as Google Drive, Dropbox, Amazon S3, SMB/CIFS fileservers, and FTP servers 
 in ownCloud. Your ownCloud server administrator controls which of these are 
 available to you. Please see `Configuring External Storage (GUI) 
-<https://doc.owncloud.org/server/9.0/admin_manual/configuration/files/
+<https://doc.owncloud.org/server/10.0/admin_manual/configuration/files/
 external_storage_configuration_gui.html>`_ in the ownCloud Administrator's 
 manual for configuration howtos and examples.

--- a/user_manual/external_storage/external_storage.rst
+++ b/user_manual/external_storage/external_storage.rst
@@ -6,6 +6,6 @@ The External Storage application allows you to mount external storage services,
 such as Google Drive, Dropbox, Amazon S3, SMB/CIFS fileservers, and FTP servers 
 in ownCloud. Your ownCloud server administrator controls which of these are 
 available to you. Please see `Configuring External Storage (GUI) 
-<https://doc.owncloud.org/server/10.0/admin_manual/configuration/files/
+<https://doc.owncloud.org/server/latest/admin_manual/configuration/files/
 external_storage_configuration_gui.html>`_ in the ownCloud Administrator's 
 manual for configuration howtos and examples.


### PR DESCRIPTION
I just noticed this broken link in the online manual.
Probably something else needs to be done to make it more generic? Rather than a hard-coded version number.