### PR TITLE
Change style of active navigation link

### DIFF
--- a/_shared_assets/themes/owncloud_org/static/styles.css
+++ b/_shared_assets/themes/owncloud_org/static/styles.css
@@ -349,10 +349,10 @@ ul#menu-support.menu > ul li.toctree-l1.current {
   padding-bottom: 10px;
 }
 /* override the color of links */
-ul#menu-support.menu ul > li.current > a:hover,
-ul#menu-support.menu ul > li.current > a:focus,
-ul#menu-support.menu ul > li.current > a {
-  color: white;
+ul#menu-support.menu ul > li.current > a[class="reference internal"]:hover,
+ul#menu-support.menu ul > li.current > a[class="reference internal"]:focus,
+ul#menu-support.menu ul > li.current > a[class="reference internal"] {
+ font-style: italic;
 }
 /* override the color of the current link */
 ul#menu-support.menu ul > li.current > a.current {


### PR DESCRIPTION
@jamesrhea from [the Write the Docs Slack channel](http://slack.writethedocs.org) pointed out that the font colour of the active link in the navigation menu, in the .org version of the documentation, is white — **on a white background**. This commit was created to fix that readability problem as well as to improve readability by italicising the active link.