### PR TITLE
Update occ security:certificates command syntax

### DIFF
--- a/admin_manual/configuration/server/occ_command.rst
+++ b/admin_manual/configuration/server/occ_command.rst
@@ -1405,13 +1405,13 @@ Import a new certificate:
 
 ::
 
- sudo -u www-data php occ security:import /path/to/certificate
+ sudo -u www-data php occ security:certificates:import /path/to/certificate
  
 Remove a certificate:
 
 ::
 
- sudo -u www-data php occ security:remove [certificate name]
+ sudo -u www-data php occ security:certificates:remove [certificate name]
 
 .. _sharing_commands_label:
 


### PR DESCRIPTION
Documentation was missing the full command - added/updated to reflect the full command