### PR TITLE
user:sync "disable" instead of "remove"

### DIFF
--- a/admin_manual/configuration/server/occ_command.rst
+++ b/admin_manual/configuration/server/occ_command.rst
@@ -1852,7 +1852,7 @@ Here is an example for syncing with LDAP four times a day on Ubuntu:
 
   crontab -e -u www-data
   
-  * */6 * * * /usr/bin/php /var/www/owncloud/occ user:sync -vvv --missing-account-action="remove" -n "OCA\User_LDAP\User_Proxy"
+  * */6 * * * /usr/bin/php /var/www/owncloud/occ user:sync -vvv --missing-account-action="disable" -n "OCA\User_LDAP\User_Proxy"
  
 .. _versions_label:
  


### PR DESCRIPTION
I changed the proposed "remove" in favor of "disable" because there is no undo!
Admins can still remove users who have been set to "disable", but they can not bring back removed accounts.