### PR TITLE
Further document occ:encryption:recreate-master-key

### DIFF
--- a/admin_manual/configuration/files/encryption_configuration.rst
+++ b/admin_manual/configuration/files/encryption_configuration.rst
@@ -400,6 +400,13 @@ Use this when you have:
 
 .. important::
    It is not possible to disable it.
+   
+Recreating an Existing Master Key
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If the master key needs replacing, for example, because it has been compromised, an occ command is available.
+The command is :ref:`encryption:recreate-master-key <encryption_label>`.
+It replaces existing master key with new one and encrypts the files with the new key.
  
 Disabling Encryption
 --------------------


### PR DESCRIPTION
This PR adds further documentation on the `occ:encryption:recreate-master-key` command to the documentation, in `admin_manual/configuration/files/encryption_configuration.rst`. 

### Relates To 

#3626.