### PR TITLE
Correct reference to enabling single user mode

### DIFF
--- a/admin_manual/configuration/files/encryption_configuration.rst
+++ b/admin_manual/configuration/files/encryption_configuration.rst
@@ -342,7 +342,7 @@ For performance reasons, when you enable encryption on an ownCloud server only n
 This command gives you the option to encrypt all files. 
 You must first put your ownCloud server into single-user mode to prevent any user activity until encryption is completed::
 
- occ maintenance:singleuser
+ occ maintenance:singleuser --on
  Single user mode is currently enabled
 
 Then run ``occ``::


### PR DESCRIPTION
This commit corrects an incorrect reference to enabling single-user mode.

### Fixes 

#3641.