### PR TITLE
Update antivirus configuration location in 10.0.4

### DIFF
--- a/admin_manual/configuration/server/antivirus_configuration.rst
+++ b/admin_manual/configuration/server/antivirus_configuration.rst
@@ -155,7 +155,7 @@ Next, go to your ownCloud Admin page and set your ownCloud logging level to Ever
 
 .. figure:: ../../images/antivirus-logging.png
 
-Now, navigate to ``Settings -> Admin -> Additional``, where you'll find the "**Antivirus Configuration**" panel.
+Now, navigate to ``Settings -> Admin -> Security``, where you'll find the "**Antivirus Configuration**" panel.
 There, as below, you'll see the configuration options which ownCloud will pass
 to ClamAV. 
 


### PR DESCRIPTION
This PR fixes [the issue raised by ekhaskel in ownCloud Central](https://central.owncloud.org/t/problem-with-antivirus-configuration/11208), where the location in the ownCloud admin for configuring the antivirus is wrong for 10.0.4