### PR TITLE
Add ability to set manual version & release strings from the command …

### DIFF
--- a/admin_manual/Makefile
+++ b/admin_manual/Makefile
@@ -7,11 +7,16 @@ SPHINXBUILD   = sphinx-build
 PAPER         =
 BUILDDIR      = _build
 
+# Set the version string from a command-line argument, if it's supplied, otherwise
+# fallback to setting it from the existing configuration in conf.py
+ifeq ($(OC_VERSION),)
+  OC_VERSION := $( grep -e "^version" conf.py | awk -F" = " '{print $2}' | tr -d "'" )
+endif
+
 # Internal variables.
 PAPEROPT_a4     = -D latex_paper_size=a4
-PAPEROPT_letter = -D latex_paper_size=letter
-ALLSPHINXOPTS   = -d $(BUILDDIR)/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
-# the i18n builder cannot share the environment and doctrees with the others
+PAPEROPT_letter = -D latex_paper_size=letterALLSPHINXOPTS   = -d $(BUILDDIR)/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
+ALLSPHINXOPTS   = -d $(BUILDDIR)/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) -D version=$(OC_VERSION) -D release=$(OC_VERSION) .
 I18NSPHINXOPTS  = $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
 
 .PHONY: help clean html dirhtml singlehtml pickle json htmlhelp qthelp devhelp epub latex latexpdf text man changes linkcheck doctest gettext

--- a/developer_manual/Makefile
+++ b/developer_manual/Makefile
@@ -7,10 +7,16 @@ SPHINXBUILD   = sphinx-build
 PAPER         =
 BUILDDIR      = _build
 
+# Set the version string from a command-line argument, if it's supplied, otherwise
+# fallback to setting it from the existing configuration in conf.py
+ifeq ($(OC_VERSION),)
+  OC_VERSION := $( grep -e "^version" conf.py | awk -F" = " '{print $2}' | tr -d "'" )
+endif
+
 # Internal variables.
 PAPEROPT_a4     = -D latex_paper_size=a4
 PAPEROPT_letter = -D latex_paper_size=letter
-ALLSPHINXOPTS   = -d $(BUILDDIR)/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
+ALLSPHINXOPTS   = -d $(BUILDDIR)/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) -D version=$(OC_VERSION) -D release=$(OC_VERSION) .
 # the i18n builder cannot share the environment and doctrees with the others
 I18NSPHINXOPTS  = $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
 

--- a/user_manual/Makefile
+++ b/user_manual/Makefile
@@ -7,10 +7,16 @@ SPHINXBUILD   = sphinx-build
 PAPER         =
 BUILDDIR      = _build
 
+# Set the version string from a command-line argument, if it's supplied, otherwise
+# fallback to setting it from the existing configuration in conf.py
+ifeq ($(OC_VERSION),)
+  OC_VERSION := $( grep -e "^version" conf.py | awk -F" = " '{print $2}' | tr -d "'" )
+endif
+
 # Internal variables.
 PAPEROPT_a4     = -D latex_paper_size=a4
 PAPEROPT_letter = -D latex_paper_size=letter
-ALLSPHINXOPTS   = -d $(BUILDDIR)/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
+ALLSPHINXOPTS   = -d $(BUILDDIR)/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) -D version=$(OC_VERSION) -D release=$(OC_VERSION) .
 # the i18n builder cannot share the environment and doctrees with the others
 I18NSPHINXOPTS  = $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
 


### PR DESCRIPTION
This PR updates the Makefiles for all three manuals to set the version and release strings based on a supplied command-line argument. If an argument's not supplied, then the value will be set by falling back to using the value set in the respective manual's `conf.py` configuration file. This fixes #3732.