### PR TITLE
Fixed up the organisation of the files commands

### DIFF
--- a/admin_manual/configuration/server/occ_command.rst
+++ b/admin_manual/configuration/server/occ_command.rst
@@ -619,6 +619,11 @@ File Operations
 .. note::
   These commands are not available in :ref:`single-user (maintenance) mode <maintenance_commands_label>`.
 
+The files:cleanup command
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+``files:cleanup`` tidies up the server's file cache by deleting all file entries that have no matching entries in the storage table. 
+
 The files:scan command
 ^^^^^^^^^^^^^^^^^^^^^^
 
@@ -700,13 +705,11 @@ The following commands show how to enable single user mode, run a repair file sc
 .. note:: 
    We strongly suggest that you backup the database before running this command.
 
-The files:cleanup command
-^^^^^^^^^^^^^^^^^^^^^^^^^
+The files:transfer-ownership command
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-``files:cleanup`` tidies up the server's file cache by deleting all file entries that have no matching entries in the storage table. 
 You may transfer all files and shares from one user to another. 
 This is useful before removing a user. 
-
 For example, to move all files from ``<source-user>`` to ``<destination-user>``, use the following command:
 
 ::


### PR DESCRIPTION
Previously, the order of the file command's documentation wasn't consistent with how it starts off and the `files:cleanup` section wasn't being distinguished from the `files:transfer-ownership` section. This reorganisation and cleanup fixes that. 

### Fixes 

#3743. 