### PR TITLE
Add a script for bootstrapping ownCloud themes

### DIFF
--- a/developer_manual/core/theming.rst
+++ b/developer_manual/core/theming.rst
@@ -13,6 +13,11 @@ However, this documentation only covers customizing the web front-end, *so far*.
    sure you change any references to match the location of your owncloud
    installation.
 
+To save you time and effort, you can use the shell script below, to create the basis of a new theme from ownCloud's example theme.
+
+.. literalinclude:: ../scripts/theme-bootstrap.sh
+   :language: bash
+
 How to Create a New Theme
 -------------------------
 

--- a/developer_manual/scripts/theme-bootstrap.sh
+++ b/developer_manual/scripts/theme-bootstrap.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+# theme-bootstrap.sh
+# Invoke this script with one argument, the new theme's name.
+# Written by Dmitry Mayorov <dmitry@owncloud.com> & Matthew Setter <matthew@matthewsetter.com>
+# Copyright (c) ownCloud 2018.
+set -e
+
+E_BADARGS=85
+
+if (( $# != 2 ))
+then
+  echo "Not enough arguments supplied."
+  echo "Usage: $( basename "$0" ) [-v] [-h] [theme id] [owncloud directory]"
+  exit $E_BADARGS
+fi
+
+app_name="$1"
+owncloud_directory="$2"
+apps="$owncloud_directory/apps"
+
+OLDPWD=${OLDPWD:=$(pwd)}
+
+echo "Bootstrapping theme development."
+
+cd "$owncloud_directory"
+
+# Copy the example theme to your theme
+echo 
+echo "Copying default theme"
+cp -r "$apps/theme-example" "$apps/$app_name"
+
+# Remove the default signature, which will cause a code integrity violation
+if [ -f "$apps/$app_name/appinfo/signature.json" ]; then
+  echo 
+  echo "Removing default signature.json file to avoid code integrity violation"
+  rm "$apps/$app_name/appinfo/signature.json"
+fi
+
+# Replace the default id
+echo 
+echo "Updating theme id"
+sed -i "s#<id>theme-example<#<id>$app_name<#" "$apps/$app_name/appinfo/info.xml"
+
+# Set the appropriate permissions
+echo
+echo "Setting theme file permissions"
+chown -R www-data:www-data "$apps/$app_name"
+
+# Enable the theme (app)
+echo 
+echo "Enabling theme"
+sudo -u www-data php "$owncloud_directory/occ" app:enable "$app_name"
+
+echo
+echo "Finished bootstrapping the new theme."
+
+cd "$OLDPWD" 


### PR DESCRIPTION
This PR provides a small script for bootstrapping a new theme based off of ownCloud's default/example theme. 

💁 This is a slight modification of the original by @voroyam.