### PR TITLE
Fix issues causing the build to fail

### DIFF
--- a/admin_manual/appliance/index.rst
+++ b/admin_manual/appliance/index.rst
@@ -10,3 +10,4 @@ The ownCloud X Appliance
    howto-update-owncloud
    managing-ucs
    clamav
+   Collabora

--- a/admin_manual/configuration/ldap/ldap_proxy_cache_server_setup.rst
+++ b/admin_manual/configuration/ldap/ldap_proxy_cache_server_setup.rst
@@ -104,8 +104,8 @@ or
 
   ldapsearch -H ldaps://localhost:636 -x -LLL -D "cn=admin,cn=users,dc=example,dc=com" -b "cn=users,dc=example,dc=com" -W "(cn=Administrator)" name
 
--h = host adress (Example: localhost or 192.168.1.1)
--H = host adress (Example: ldap:// or ldaps:// hostname or ip and port :389 or :636 )
+-h = host address (Example: localhost or 192.168.1.1)
+-H = host address (Example: ``ldap://`` or ``ldaps://`` hostname or ip and port :389 or :636 )
 -x = simple authentication
 -b = Search Base, (Example: "cn=Users,dc=example,dc=com")
 -D = User with permissions (Example: "cn=Admin,dc=example,dc=com")

--- a/admin_manual/configuration/server/oc_server_tuning.rst
+++ b/admin_manual/configuration/server/oc_server_tuning.rst
@@ -8,12 +8,6 @@ Using Cron to Perform Background Jobs
 See :doc:`background_jobs_configuration` for a description and the 
 benefits.
 
-Enable JavaScript and CSS Asset Management
-------------------------------------------
-
-See :doc:`js_css_asset_management_configuration` for a description and the 
-benefits.
-
 .. _caching:
 
 Enable Memory Caching

--- a/admin_manual/configuration/server/occ_command.rst
+++ b/admin_manual/configuration/server/occ_command.rst
@@ -1512,7 +1512,7 @@ Ransomware Protection
 ---------------------
 
 Use these commands to help users recover from a Ransomware attack.
-You can find more information about the application :doc:`in the documentation <security/ransomware-protection>`.
+You can find more information about the application :doc:`in the documentation <../../enterprise/ransomware-protection/index>`.
 
 .. note:: Ransomware Protection (which is an Enterprise app) needs to be installed and enabled to be able to use these commands.
 

--- a/admin_manual/configuration/server/security/password-policy.rst
+++ b/admin_manual/configuration/server/security/password-policy.rst
@@ -22,7 +22,7 @@ It supports configuring a basic password policy, which includes:
 #. Setting a password length
 #. Whether to enforce at least one upper and lower case character, a numerical character and a special character.
 
-.. figure:: ../../../configuration/files/images/security-app-password-policy.png
+.. figure:: ../../../images/configuration/server/security/security-app-password-policy.png
 
 
 .. Links

--- a/admin_manual/enterprise/ransomware-protection/index.rst
+++ b/admin_manual/enterprise/ransomware-protection/index.rst
@@ -18,7 +18,7 @@ About Ransomware Protection
 
 The app is tasked with *detecting*, *preventing*, and *reverting* anomalies.
 Anomalies are file operations (including *create*, *update*, *delete*, and *move*) not intentionally conducted by the user.
-It aims to do so in two ways: `prevention <ransomware_prevention_label>`_, and `protection <ransomware_protection_label>`_.
+It aims to do so in two ways: :ref:`prevention <ransomware_prevention_label>`, and :ref:`protection <ransomware_protection_label>`.
 
 .. _ransomware_prevention_label:
 
@@ -36,7 +36,7 @@ The first line of defense against such threats is a blacklist that blocks write 
 
 Ransomware Protection ships with `a static extension list`_ of around 1,500 file extensions.
 As new extensions are regularly created, this list also needs to be regularly reviewed and updated.
-Future releases of Ransomware Protection will include an updated list and the ability to update the list via syncing with `FSRM's API`_ by using :doc:`occ <../occ_command>`.
+Future releases of Ransomware Protection will include an updated list and the ability to update the list via syncing with `FSRM's API`_ by using :doc:`occ <../../configuration/server/occ_command>`.
 
 .. important:: 
    Please check the provided ransomware blacklist!

--- a/admin_manual/maintenance/upgrade.rst
+++ b/admin_manual/maintenance/upgrade.rst
@@ -30,14 +30,11 @@ After the upgrade is complete re-enable any which are compatible with the new re
 .. warning::
    Install unsupported apps at your own risk.
 
-.. _owncloud.org/install/:
-   https://owncloud.org/install/  
-
 Upgrade Options
 ---------------
 
 There are three ways to upgrade your ownCloud server.
-The first — *and recommended* — way is to perform a :doc:`manual upgrade <manual_upgrade>`, using `the latest ownCloud release <owncloud.org/install/>`_.
+The first — *and recommended* — way is to perform a :doc:`manual upgrade <manual_upgrade>`, using `the latest ownCloud release <https://owncloud.org/install/>`_.
 The second way is to use your distribution's :doc:`package manager <package_upgrade>`, in conjunction with our official ownCloud repositories. 
 However, this approach should not be used unattended nor in clustered setups.
 


### PR DESCRIPTION
There were a series of broken links, both to other content and to files that caused the build to break when attempting to build a PDF.