### PR TITLE
Update LDAP docs

### DIFF
--- a/admin_manual/configuration/user/user_auth_ldap.rst
+++ b/admin_manual/configuration/user/user_auth_ldap.rst
@@ -403,19 +403,6 @@ Quota Default:
   Override ownCloud's default quota *for LDAP users* who do not have a quota set in 
   the Quota Field, e.g., ``15 GB``.
 
-Email Field:
-  Set the user's email from an LDAP attribute, e.g., ``mail``. Leave it empty for default 
-  behavior.
-
-User Home Folder Naming Rule:
-  By default, the ownCloud server creates the user directory in your ownCloud 
-  data directory and gives it the ownCloud username, e.g., ``/var/www/owncloud/data/alice`` 
-  if your data directory is set to be ``/var/www/owncloud/data``.
-
-  You may want to override this setting and name it after an LDAP
-  attribute value, e.g., ``cn``. The attribute can return either an absolute path, e.g. 
-  ``/mnt/storage43/alice`` or a relative path which must not begin with a ``/``, e.g. ``CloudUsers/CookieMonster``. This relative path is then created inside the data directory (e.g. ``/var/www/owncloud/data/CloudUsers/CookieMonster``). Leave it empty for default behavior.
-
 Please bear in mind the following, when using these fields to assign user quota limits. 
 It should help to alleviate any, potential, confusion.
 
@@ -426,13 +413,38 @@ It should help to alleviate any, potential, confusion.
 
 .. note:: 
    Administrators are not allowed to modify the user quota limit in the user management page when steps 3 or 4 are in effect. At this point, updates are only possible via LDAP.
+   
+  See the `LDAP Schema for OwnCloud Quota <https://github.com/valerytschopp/owncloud-ldap-schema>`_
 
-In new ownCloud installations (8.0.10, 8.1.5, 8.2.0 and up) the home folder rule is enforced. This means that once you set a home folder naming rule (get a home folder from an LDAP attribute), it must be available for all users. If it isn't available for a user, then that user will not be able to login. Also, the filesystem will not be set up for that user, so their file shares will not be available to other users.
+Email Field:
+  Set the user's email from an LDAP attribute, e.g., ``mail``. Leave it empty for default 
+  behavior.
 
-In existing ownCloud installations the old behavior still applies, which is using the ownCloud username as the home folder when an LDAP attribute is not set. You may change this to enforcing the home folder rule with the ``occ`` command in ownCloud 8.2, like this example on Ubuntu::
+.. _user-home-folder-naming-rule:
+
+User Home Folder Naming Rule:
+  By default, the ownCloud server creates the user directory in your ownCloud 
+  data directory and gives it the ownCloud username, e.g., ``/var/www/owncloud/data/5a9df029-322d-4676-9c80-9fc8892c4e4b`` 
+  if your data directory is set to be ``/var/www/owncloud/data``.
+
+  It is possible to override this setting and name it after an LDAP
+  attribute value, e.g., ``attr:cn``. The attribute can return either an absolute path, e.g. 
+  ``/mnt/storage43/alice`` or a relative path which must not begin with a ``/``, e.g. ``CloudUsers/CookieMonster``.
+  This relative path is then created inside the data directory (e.g. ``/var/www/owncloud/data/CloudUsers/CookieMonster``).
+  
+  Since ownCloud 8.0.10, 8.1.5, 8.2.0 and up the home folder rule is enforced. This means that once you
+  set a home folder naming rule (get a home folder from an LDAP attribute), it must be available for all
+  users. If it isn't available for a user, then that user will not be able to login. Also, the filesystem
+  will not be set up for that user, so their file shares will not be available to other users.
+  For older versions you may enforce the home folder rule with the ``occ`` command, like this example on Ubuntu::
 
   sudo -u www-data php occ config:app:set user_ldap enforce_home_folder_naming_rule --value=1 
-  
+
+  Since ownCloud 10 the home folder naming rule is only applied when first provisioning
+  the user. This prevents data loss due to reprovisioning the users home folder in case
+  of unintentional changes in LDAP.
+
+
 Expert Settings
 ---------------
 

--- a/admin_manual/configuration/user/user_auth_ldap.rst
+++ b/admin_manual/configuration/user/user_auth_ldap.rst
@@ -387,7 +387,15 @@ Group Member association:
   ownCloud detects the value automatically. You should only change it if you
   have a very valid reason and know what you are doing.
 
-  * Example: *uniquemember*
+  * Example:
+
+    | *member* with FDN for Active Directory or for objectclass ``groupOfNames`` groups
+    | *memberUid* with RDN for objectclass ``posixGroup`` groups
+    | *uniqueMember* with FDN for objectclass ``groupOfUniqueNames`` groups
+
+Dynamic Group Member URL
+  The LDAP attribute that on group objects contains an LDAP search URL that determines what objects belong to the group.
+  An empty setting disables dynamic group membership functionality. See `Configuring Dynamic Groups <http://www.zytrax.com/books/ldap/ch11/dynamic.html>`_ for more details.
 
 Nested Groups:
   This makes the LDAP connector aware that groups could be stored inside existing group records. 

--- a/admin_manual/configuration/user/user_auth_ldap.rst
+++ b/admin_manual/configuration/user/user_auth_ldap.rst
@@ -308,12 +308,22 @@ Directory Settings
 User Display Name Field:
   The attribute that should be used as display name in ownCloud.
 
-  *  Example: *displayName*
+  * Example:
+
+    | *displayName*
+    | *givenName*
+    | *sn*
   
 2nd User Display Name Field:  
   An optional second attribute displayed in brackets after the display name, 
   for example using the ``mail`` attribute displays as ``Molly Foo 
   (molly@example.com)``.
+
+  * Example:
+
+    | *mail*
+    | *userPrincipalName*
+    | *sAMAccountName*
 
 Base User Tree:
   The base DN of LDAP, from where all users can be reached. This must be a 
@@ -526,13 +536,10 @@ users and groups are fetched correctly on the Users page.
 Syncing Users
 -------------
 
-You need to sync all LDAP users to your ownCloud database after they've been created, using :ref:`the occ command <syncing_user_accounts_label>`.
-Versions of ownCloud before 10.0 imported all users when the user page loaded, but this is no longer the case. 
+While users who match the login and user filters can log in, only synced users will be found in the sharing dialog. Whenever users log in their display name, email, quota, avatar and search attributes will be synced to ownCloud. If you want to keep the metadata up to date you can set up a cron job, using :ref:`the occ command <syncing_user_accounts_label>`.
+Versions of ownCloud before 10.0 imported all users when the users page was loaded, but this is no longer the case. 
 
-In versions of ownCloud from 10.0 onward, un-synced users *can* log in, **but** LDAP account changes won’t be reflected in ownCloud. 
-This includes user quotas and search option changes.
-
-Therefore, we recommend :ref:`creating a Cron job <cron_job_label>`, to automate regularly syncing LDAP users with your ownCloud database.
+We recommend :ref:`creating a Cron job <cron_job_label>`, to automate regularly syncing LDAP users with your ownCloud database.
 
 How Often Should the Job Run?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/admin_manual/configuration/user/user_auth_ldap.rst
+++ b/admin_manual/configuration/user/user_auth_ldap.rst
@@ -443,14 +443,14 @@ Email Field:
 User Home Folder Naming Rule:
   By default, the ownCloud server creates the user directory in your ownCloud 
   data directory and gives it the ownCloud username, e.g., ``/var/www/owncloud/data/5a9df029-322d-4676-9c80-9fc8892c4e4b`` 
-  if your data directory is set to be ``/var/www/owncloud/data``.
+  if your data directory is set to ``/var/www/owncloud/data``.
 
   It is possible to override this setting and name it after an LDAP
   attribute value, e.g., ``attr:cn``. The attribute can return either an absolute path, e.g. 
   ``/mnt/storage43/alice`` or a relative path which must not begin with a ``/``, e.g. ``CloudUsers/CookieMonster``.
   This relative path is then created inside the data directory (e.g. ``/var/www/owncloud/data/CloudUsers/CookieMonster``).
   
-  Since ownCloud 8.0.10, 8.1.5, 8.2.0 and up the home folder rule is enforced. This means that once you
+  Since ownCloud 8.0.10 and up the home folder rule is enforced. This means that once you
   set a home folder naming rule (get a home folder from an LDAP attribute), it must be available for all
   users. If it isn't available for a user, then that user will not be able to login. Also, the filesystem
   will not be set up for that user, so their file shares will not be available to other users.
@@ -458,7 +458,7 @@ User Home Folder Naming Rule:
 
   sudo -u www-data php occ config:app:set user_ldap enforce_home_folder_naming_rule --value=1 
 
-  Since ownCloud 10 the home folder naming rule is only applied when first provisioning
+  Since ownCloud 10.0 the home folder naming rule is only applied when first provisioning
   the user. This prevents data loss due to reprovisioning the users home folder in case
   of unintentional changes in LDAP.
 


### PR DESCRIPTION
Updated the home folder naming rule to include changes introduced with oc10. reorder paragraphs to put quota and home folder related stuff in the right flow. Added link to LDAP schema example.

cc @dercorn 