### PR TITLE
Bump firefox min version to 57

### DIFF
--- a/admin_manual/installation/system_requirements.rst
+++ b/admin_manual/installation/system_requirements.rst
@@ -37,7 +37,7 @@ Web Browser
 
 - Edge (current version on Windows 10)
 - IE11+ (except Compatibility Mode)
-- Firefox 55+ or 52 ESR
+- Firefox 57+ or 52 ESR
 - Chrome 61+
 - Safari 10+
 


### PR DESCRIPTION
Mozilla Firefox browser is currently at version 58. We do automated tests with Firefox 57 and they pass. Firefox 55 is a bit "old" and I expect that people using Firefox either keep up-to0date or use the ESR version.

So bump the Firefox current version support documented here.