### PR TITLE
Backport: Remove dead link from Shibboleth documentation

### DIFF
--- a/admin_manual/enterprise/user_management/user_auth_shibboleth.rst
+++ b/admin_manual/enterprise/user_management/user_auth_shibboleth.rst
@@ -27,8 +27,6 @@ A successful installation and configuration will populate Apache environment
 variables with at least a unique user id which is then used by the ownCloud
 Shibboleth app to login a user.
 
-See the `documentation Wiki <https://github.com/owncloud/documentation/wiki/Shibboleth-example-configurations>`_ for more configuration examples.
-
 Apache Configuration
 ^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
### Fixes 

#3807.

### Backports 

#3826.