### PR TITLE
Adding a note in files:scan about the --path option and mounts recieved

### DIFF
--- a/admin_manual/configuration/server/occ_command.rst
+++ b/admin_manual/configuration/server/occ_command.rst
@@ -681,6 +681,11 @@ For example:
   --path="/alice/files/Music"
 
 In the example above, the user_id ``alice`` is determined implicitly from the path component given.
+
+.. note::
+  Mounts are only scannable at the point of origin. Scanning of shares including federated shares 
+  is not necessary on the receiver side and therefore not possible.
+
 The ``--path``, ``--all`` and ``[user_id]`` parameters are exclusive - only one must be specified.
 
 The ``--repair`` Option


### PR DESCRIPTION
This is a small update of the `files:scan` command description with respect to the `--path` option.
I came across this when working on https://github.com/owncloud/core/issues/30596, which extend `./occ files:scan` for mount points.

You can double check by running a `files:scan --path` command on a received share or received federated share name. Nothing gets scanned. If you do not know this, you enter the received mount name as target to be scanned and wonder why nothing is done.