### PR TITLE
Augment the dt & dd css style for the ownCloud docs themes

### DIFF
--- a/_shared_assets/themes/owncloud_org/static/styles.css
+++ b/_shared_assets/themes/owncloud_org/static/styles.css
@@ -407,6 +407,10 @@ ul, ol {
   margin-bottom: 20px;
 }
 
+dl dd, dl dt {
+  margin-bottom: 10px;
+}
+
 /* Match all code highlight blocks, regardless of language */
 div[class*='highlight'] {
   margin-top: 25px;

--- a/_shared_assets/themes/owncloud_release/static/styles.css
+++ b/_shared_assets/themes/owncloud_release/static/styles.css
@@ -378,6 +378,10 @@ li.next {
   max-width: 100%;
 }
 
+dl dd, dl dt {
+  margin-bottom: 10px;
+}
+
 @media (min-width: 1200px) {
   .banner ul#menu-header.nav>li:not(.menu-install)>a {
 	width: auto;


### PR DESCRIPTION
This change adjusts the `dt` & `dd` styles so that there is a bit of spacing after the header and body of these elements. It makes the content that much easier to read.