### PR TITLE
Encourage users to store themes in a custom app directory

### DIFF
--- a/developer_manual/core/theming.rst
+++ b/developer_manual/core/theming.rst
@@ -35,8 +35,12 @@ At its most basic, to create a theme requires two steps:
 
 All themes, whether copied or new, must meet two key criteria, these are:
 
-1. They must be located in a directory under the ``apps`` directory of your ownCloud installation.
-2. They require a configuration file called ``appinfo/info.xml`` to be present.
+#. They must be store in an app directory of your ownCloud installation, whether that’s the core app directory (``apps``) or `a custom app directory`_.
+#. They require a configuration file called ``appinfo/info.xml`` to be present.
+
+.. note:: 
+   To ensure that custom themes aren’t lost during upgrades, we strongly
+   encourage you to store them in `a custom app directory`_.
 
 .. note:: 
    When copying the example theme supplied with ownCloud in ``apps/theme-example``, make sure that you delete ``appinfo/signature.json``. If you don’t, when you make changes, an integrity warning will be triggered, as the original theme is `signed`_. To get rid of the warning you have to remove (or move) ``appinfo/signature.json`` and then trigger a rescan, in the admin page, which you can see in the screenshot below.
@@ -357,3 +361,4 @@ If you think a new section should be added to core however, please create a PR w
 .. _this example: https://github.com/owncloud/core/blob/master/lib/private/Settings/SettingsManager.php#L195   
 .. _signed: /app/advanced/code_signing.html?highlight=sign
 .. _the marketplace: https://marketplace.owncloud.com
+.. _a custom app directory: https://doc.owncloud.org/server/latest/admin_manual/installation/apps_management_installation.html#using-custom-app-directories


### PR DESCRIPTION
This PR encourages users to use a custom app directory to store themes. The reason behind this is to help ensure that upgrades are as smooth as possible and that custom themes are not corrupted or lost during an upgrade.

### Fixes

#3874.