### PR TITLE
wrong return code in .htaccess / The network name cannot be found

### DIFF
--- a/admin_manual/issues/general_troubleshooting.rst
+++ b/admin_manual/issues/general_troubleshooting.rst
@@ -292,7 +292,7 @@ main Web server / Vhost configuration or the ``.htaccess`` placed in your docume
     RewriteEngine On
     RewriteCond %{REQUEST_URI} ^(/)$ [NC]
     RewriteCond %{REQUEST_METHOD} ^(OPTIONS)$
-    RewriteRule .* https://%{SERVER_NAME}/owncloud/remote.php/webdav/ [R=301,L]
+    RewriteRule .* https://%{SERVER_NAME}/owncloud/remote.php/webdav/ [R=401,L]
 
 For NGINX an example config addition could be::
 


### PR DESCRIPTION
See original issue comment: https://github.com/owncloud/core/issues/26350#issuecomment-288057762
Mistyped 301 instead of 401, needs to be fixed.