### PR TITLE
Move of UI acceptance tests into acceptance folder

### DIFF
--- a/developer_manual/core/ui-testing.rst
+++ b/developer_manual/core/ui-testing.rst
@@ -132,7 +132,7 @@ You can run the UI tests for just a single suite by specifying the suite name:
 
   bash tests/travis/start_ui_tests.sh --suite files
   
-The names of suites are found in the ``behat.yml`` file.
+The names of suites are found in the ``tests/acceptance/config/behat.yml`` file, and start with ``webUI``.
 
 Running UI Tests for One Feature
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -141,13 +141,13 @@ You can run the UI tests for just a single feature by specifying the feature fil
 
 .. code-block:: console
 
-  bash tests/travis/start_ui_tests.sh --feature tests/ui/features/other/login.feature
+  bash tests/travis/start_ui_tests.sh --feature tests/acceptance/features/webUITrashbin/trashbinDelete.feature
 
 To run just a single scenario within a feature, specify the line number of the scenario:
 
 .. code-block:: console
 
-  bash tests/travis/start_ui_tests.sh --feature tests/ui/features/other/login.feature:<linenumber>
+  bash tests/travis/start_ui_tests.sh --feature tests/acceptance/features/webUITrashbin/trashbinDelete.feature:<linenumber>
 
 Running UI Tests for an App
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -156,13 +156,13 @@ With the app installed, run the UI tests for the app by specifying the location 
 
 .. code-block:: console
 
-  bash tests/travis/start_ui_tests.sh --config apps/files_texteditor/tests/ui/config/behat.yml
+  bash tests/travis/start_ui_tests.sh --config apps/files_texteditor/tests/acceptance/config/behat.yml
 
 Run UI the tests for just a single feature of the app by also specifying the feature file:
 
 .. code-block:: console
 
-  bash tests/travis/start_ui_tests.sh --config apps/files_texteditor/tests/ui/config/behat.yml --feature apps/files_texteditor/tests/ui/features/createtextfile.feature
+  bash tests/travis/start_ui_tests.sh --config apps/files_texteditor/tests/acceptance/config/behat.yml --feature apps/files_texteditor/tests/acceptance/features/textfiles.feature
 
 Skipping Tests
 ~~~~~~~~~~~~~~


### PR DESCRIPTION
Core PR https://github.com/owncloud/core/pull/30722 has move the ``tests/ui`` folder contents over to ``tests/acceptance`` - so the UI test feature files etc are now located under ``tests/acceptance``

This updates the documentation for that.
