### PR TITLE
Fix & reorganise developer doc help links

### DIFF
--- a/developer_manual/commun/help_and_communication.rst
+++ b/developer_manual/commun/help_and_communication.rst
@@ -1,38 +1,38 @@
 =================
-Getting Involved 
+Getting Involved
 =================
 
 There are a variety of ways to get involved and seek help if and when you need
-it. 
+it.
 Here's the best ways.
 
 Mailing lists
 -------------
 
-On the `mailing lists <https://mailman.owncloud.org>`_.
+On the `mailing lists`_.
 
 Community support forum
 -----------------------
 
-Ask questions on `ownCloud Central <http://www.central.owncloud.org/>`_. 
-We strongly recommend using ownCloud Central, as it hosts dedicated FAQ pages. 
+Ask questions on `ownCloud Central`_.
+We strongly recommend using ownCloud Central, as it hosts dedicated FAQ pages.
 These include topics which address typical mistakes and commonly occurring issues.
 
 Social media
 ------------
 
-Ask questions on social media. 
+Ask questions on social media.
 
-- `Google Plus <https://plus.google.com/+ownclouders/>`_
-- `Facebook <https://www.facebook.com/ownclouders/>`_
-- `Twitter <https://twitter.com/ownclouders/>`_
+- `Google Plus`_
+- `Facebook`_
+- `Twitter`_
 
 IRC channels
 ------------
 
-Chat with us on `IRC <http://www.irchelp.org/>`_ (**irc.freenode.net**).
+Chat with us on `IRC`_ (**irc.freenode.net**).
 You can chat via the web with http://webchat.freenode.net, or use your favorite IRC
-client. 
+client.
 The channel names are:
 
 - Setup: **#owncloud**
@@ -45,3 +45,12 @@ Maintainers
 
 If you need to contact a maintainer of a certain app or division you can
 find the details at https://owncloud.org/contact/.
+
+.. Links
+
+.. _ownCloud Central: http://central.owncloud.org/
+.. _mailing lists: https://mailman.owncloud.org
+.. _Google Plus: https://plus.google.com/+ownclouders/
+.. _Facebook: https://www.facebook.com/ownclouders/
+.. _Twitter: https://twitter.com/ownclouders/
+.. _IRC: http://www.irchelp.org/


### PR DESCRIPTION
The ownCloud central link was incorrect, so it was fixed. Then the remaining links were moved to the bottom of the page, to be consistent with the style guide.