### PR TITLE
Bump chrome support min to 64

### DIFF
--- a/admin_manual/installation/system_requirements.rst
+++ b/admin_manual/installation/system_requirements.rst
@@ -47,7 +47,7 @@ Web Browser
 - Edge (current version on Windows 10)
 - IE11+ (except Compatibility Mode)
 - Firefox 57+ or 52 ESR
-- Chrome 61+
+- Chrome 64+
 - Safari 10+
 
 Hypervisors 


### PR DESCRIPTION
chrome current release is 65, and we run webUI automated acceptance tests on chrome latest and latest-1