### PR TITLE
Backport: Correct the Redis code block example

### DIFF
--- a/admin_manual/configuration/server/caching_configuration.rst
+++ b/admin_manual/configuration/server/caching_configuration.rst
@@ -200,13 +200,14 @@ To check what yours is currently set to, check the ``dbindex`` value in ``config
 Here’s an example of what to look for:
 
 .. code-block:: php
-   :emphasize-lines: 5
 
-    "redis": {
-        "host": "localhost",
-        "port": 6379,
-        "timeout": 0,
-        "dbindex": 0
+    'redis': {
+        'host' => 'localhost',  // Can also be a unix domain socket => '/tmp/redis.sock'
+        'port' => 6379,
+        'timeout' => 0,
+        'password' => '',       // Optional, if not defined no password will be used.
+        'dbindex' => 0          // Optional, if undefined SELECT will not run and will
+                                // use Redis Server's default DB Index.
     },
 
 Further Reading


### PR DESCRIPTION
### Relates To

#3903.

### Backports

#3970.