### PR TITLE
Correct references to the Versions app use of a user's quota

### DIFF
--- a/admin_manual/configuration/files/file_versioning.rst
+++ b/admin_manual/configuration/files/file_versioning.rst
@@ -17,8 +17,8 @@ pattern used to delete old versions:
 The versions are adjusted along this pattern every time a new version is 
 created.
 
-The Versions app never uses more that 50% of the user's currently available 
-free space. If the stored versions exceed this limit, ownCloud deletes the 
+The Versions app never uses more that 50% of the user's storage quota.
+If the stored versions exceed this limit, ownCloud deletes the
 oldest file versions until it meets the disk space limit again.
 
 You may alter the default pattern in ``config.php``. The default setting is 

--- a/user_manual/files/deleted_file_management.rst
+++ b/user_manual/files/deleted_file_management.rst
@@ -41,10 +41,10 @@ magic powers to prevent this.
 How the Deleted Files app Manages Storage Space
 -----------------------------------------------
 
-To ensure that users do not run over their storage quotas, the Deleted Files 
-app allocates a maximum of 50% of their currently available free space to 
-deleted files. If your deleted files exceed this limit, ownCloud deletes the 
-oldest files (files with the oldest timestamps from when they were deleted) 
+To ensure that users do not run over their storage quotas, the Deleted Files
+app allocates a maximum of 50% of their currently available storage quota to
+deleted files. If your deleted files exceed this limit, ownCloud deletes the
+oldest files (files with the oldest timestamps from when they were deleted)
 until it meets the memory usage limit again.
 
 ownCloud checks the age of deleted files every time new files are added to the 


### PR DESCRIPTION
This PR corrects the documentation to show that it uses a user's storage quota, not the currently available free space. 

### Relates To 

#3997.