### PR TITLE
added dhcp notice

### DIFF
--- a/admin_manual/appliance/installation.rst
+++ b/admin_manual/appliance/installation.rst
@@ -11,6 +11,7 @@ To keep it succinct, you need to:
 
 .. important:: 
    You need **Internet access** to use the appliance. The appliance has to be activated with a license that you will receive from Univention via email. This license has to be imported in the appliance via the **web interface**.
+   The appliance needs also a DHCP server in order to get an IP address to be accessable.
 
 After that, you can access the running instance of ownCloud and :ref:`further configure it <appliance-administer-label>` to suit your needs. 
 

--- a/admin_manual/appliance/installation.rst
+++ b/admin_manual/appliance/installation.rst
@@ -11,7 +11,7 @@ To keep it succinct, you need to:
 
 .. important:: 
    You need **Internet access** to use the appliance. The appliance has to be activated with a license that you will receive from Univention via email. This license has to be imported in the appliance via the **web interface**.
-   The appliance needs also a DHCP server in order to get an IP address to be accessable.
+   The appliance also needs access to a DHCP server so that it can receive an IP address and be accessible.
 
 After that, you can access the running instance of ownCloud and :ref:`further configure it <appliance-administer-label>` to suit your needs. 
 


### PR DESCRIPTION
It's important to clearly state what the appliance requires in order to work.

If it's unclear - users will install it - fail - and go to another product.