### PR TITLE
Document how to disable code coverage

### DIFF
--- a/developer_manual/core/unit-testing.rst
+++ b/developer_manual/core/unit-testing.rst
@@ -241,6 +241,12 @@ To run a particular test suite, use the following command as a guide:
 
   make test-php TEST_DATABASE=mysql TEST_PHP_SUITE=tests/lib/share/share.php
 
+By default, a code coverage report is generated after the test run. To avoid the time taken for that, specify ``NOCOVERAGE``:
+
+::
+
+  make test-php NOCOVERAGE=true TEST_DATABASE=mysql TEST_PHP_SUITE=tests/lib/share/share.php
+
 Further Reading
 ~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
when running PHPunit tests.

Because I annoy myself by forgetting to put this when running a short test locally, and the code coverage report takes 10 times as long to happen as the actual test takes to run.