### PR TITLE
Add clear and concise instructions for installing Sphinx-Doc

### DIFF
--- a/GETTING_STARTED.rst
+++ b/GETTING_STARTED.rst
@@ -54,6 +54,22 @@ Required Software
 The README on https://github.com/owncloud/documentation has instructions for setting 
 up your build environment.
 
+How to Install Sphinx-Doc
+-------------------------
+
+On Ubuntu 16.10
+~~~~~~~~~~~~~~~
+
+To install Sphinx-Doc, follow the commands below.
+This will install all of the required packages so that you build the documentation.
+
+::
+
+  apt-get update
+  apt-get install python3-sphinx python-pip python-dev build-essential make --assume-yes
+  pip install sphinxcontrib-phpdomain
+  pip install rst2pdf
+
 Release Updates
 ---------------
 


### PR DESCRIPTION
This has been a source of much confusion and frustration and it’s not properly documented by [the official documentation](http://www.sphinx-doc.org/en/master/usage/installation.html), _to the best of my knowledge_. Given that, I want to make it clear here. Ok, it saves me the time and effort of finding the instructions again if Vagrant dies on me.