### PR TITLE
Document putting a user in groups when they are being created

### DIFF
--- a/admin_manual/configuration/user/user_provisioning_api.rst
+++ b/admin_manual/configuration/user/user_provisioning_api.rst
@@ -37,6 +37,7 @@ Argument Type   Description
 ======== ====== ======================================
 userid   string The required username for the new user
 password string The required password for the new user
+groups   array  Groups to add the user to [optional]
 ======== ====== ======================================
 
 Status Codes
@@ -46,6 +47,7 @@ Status Codes
 * 101 - invalid input data
 * 102 - username already exists
 * 103 - unknown error occurred whilst adding the user
+* 104 - group does not exist
 
 Example
 ^^^^^^^
@@ -56,6 +58,12 @@ Example
   curl -X POST http://admin:secret@example.com/ocs/v1.php/cloud/users \
      -d userid="Frank" \
      -d password="frankspassword"
+
+  # Creates the user ``Frank`` with password ``frankspassword`` and adds him to the ``finance`` and ``management``groups
+  curl -X POST http://admin:secret@example.com/ocs/v1.php/cloud/users \
+     -d userid="Frank" \
+     -d password="frankspassword" \
+     -d groups[]="finance" -d groups[]="management"
 
 XML Output
 ^^^^^^^^^^


### PR DESCRIPTION
When using the provisioning API to create a user, you can put them into groups at the same time, in a single command.

It will be nice to have this documented so we all can see an example.

When a sub-admin creates a user, they have to specify a group of which they are the sub-admin, so they need to specify a group name like this.