### PR TITLE
Port #4147 to the new Antora-based documentation setup

### DIFF
--- a/modules/developer_manual/pages/core/ocs-share-api.adoc
+++ b/modules/developer_manual/pages/core/ocs-share-api.adoc
@@ -273,8 +273,7 @@ Things to remember about public link shares
 * Files will only ever have the *read* permission set
 * Folders will have *read*, *update*, *create*, and *delete* set
 * Public link shares *cannot* be shared with users and groups
-* Public link shares are not available if public link sharing is enabled
-by the administrator
+* Public link shares are not available if public link sharing is disabled by the administrator
 
 *Mandatory Fields*
 


### PR DESCRIPTION
This PR backports #4147 into the Antora build of the documentation. 