### PR TITLE
 Instructions for running local UI acceptance tests with docker 

### DIFF
--- a/developer_manual/core/ui-testing.rst
+++ b/developer_manual/core/ui-testing.rst
@@ -13,16 +13,16 @@ Requirements
 - An admin user called ``admin`` with the password ``admin``.
 - No self-signed SSL certificates.
 - Testing utils (running ``make`` in your terminal from the ``webroot`` directory will install them).
-- `Docker CE Installed <https://docs.docker.com/install/linux/docker-ce/ubuntu/>`_
-- `Docker Post-install <https://docs.docker.com/install/linux/linux-postinstall/>`_ done to put your developer account in the docker group so you can run ``docker`` without ``sudo``
-- Docker subnet enabled for any firewall that may be active. e.g. ``ufw`` might be enabled and so you should allow the ``172.17.0.0/16`` ``docker`` subnet:
+- `Docker CE Installed`_
+- `Docker Post-install`_ done to put your developer account in the docker group so you can run Docker without ``sudo``
+- Docker subnet enabled for any firewall that may be active such as, `ufw`_. The example below shows how to update ufw's firewall rules to allow the ``172.17.0.0/16`` Docker subnet:
 
   .. code-block:: console
 
     sudo ufw status
     sudo ufw allow from 172.17.0.0/16
 
-- Docker containers pulled. It is recommended to use ``standalone-chrome-debug`` which allows seeing the browser live. You will also need ``mailhog``. Pull any or all of these ``docker`` containers:
+- Docker containers pulled. It is recommended to use ``standalone-chrome-debug`` which allows seeing the browser live. You will also need `MailHog`_. Pull any or all of these Docker containers:
 
   .. code-block:: console
 
@@ -38,15 +38,14 @@ Requirements
 
     sudo apt install tigervnc-viewer
 
-- To run the selenium server locally (not in ``docker``) see the notes at the end.
+- To run the `Selenium server`_ locally (not in Docker) see the notes at the end.
 
 Overview
 ~~~~~~~~
 
-Tests are divided into suites, enabling each suite to test some logical portion of the functionality
-and for the total elapsed run-time of a single suite to be reasonable (up to about 40 minutes on Travis-CI,
-about 10 minutes on drone). Elapsed run-time on a local developer system is very dependent on the IO as well as CPU
-performance. Smaller apps may have all tests in a single suite.
+Tests are divided into suites, enabling each suite to test some logical portion of the functionality and for the total elapsed run-time of a single suite to be reasonable (up to about 40 minutes on Travis-CI, about 10 minutes on drone).
+Elapsed run-time on a local developer system is very dependent on the IO as well as CPU performance.
+Smaller apps may have all tests in a single suite.
 
 Each suite consists of a number of features. Each feature is described in a ``*.feature`` file.
 There are a number of scenarios in each feature file. Each scenario has a number of scenario steps
@@ -55,21 +54,21 @@ that define the steps taken to do the test.
 Set Up Test
 ~~~~~~~~~~~
 
-- Start the ``selenium`` ``docker`` container in a terminal:
+- Start the Selenium Docker container in a terminal:
 
   .. code-block:: console
 
     docker run -p 4445:4444 -p 5900:5900 -v /dev/shm:/dev/shm selenium/standalone-chrome-debug
 
-  Ports on the selenium docker IP address are mapped to ``localhost`` so they can be accessed by the tests and the ``vnc`` viewer.
+  Ports on the Selenium Docker IP address are mapped to ``localhost`` so they can be accessed by the tests and the ``vnc`` viewer.
 
-- Start the ``mailhog`` ``docker`` container in another terminal:
+- Start the MailHog Docker container in another terminal:
 
   .. code-block:: console
 
     docker run -p 1025:1025 -p 8025:8025 mailhog/mailhog
 
-  Ports on the mailhog docker IP address are mapped to ``localhost`` so they can be accessed by the tests.
+  Ports on the MailHog docker IP address are mapped to ``localhost`` so they can be accessed by the tests.
 
   By running these in terminal windows, it is simple to press ``ctrl-C`` to stop them when you are finished.
 
@@ -84,7 +83,7 @@ Set Up Test
   - ``BROWSER`` (Any one of ``chrome``, ``firefox``, ``internet explorer``)
   - ``BROWSER_VERSION`` (version of the browser you want to use - optional)
 
-  e.g., to test an instance running on the ``docker`` subnet with Chrome do:
+  e.g., to test an instance running on the Docker subnet with Chrome do:
 
   .. code-block:: console
 
@@ -96,7 +95,7 @@ Set Up Test
     export REMOTE_FED_SRV_HOST_PORT=8180
     export BROWSER=chrome
 
-- If your ownCloud install is running locally on Apache, then it should already be available on the ``docker``  subnet at ``172.17.0.1``
+- If your ownCloud install is running locally on Apache, then it should already be available on the Docker  subnet at ``172.17.0.1``
 
 - If you don't have a webserver already running, leave SRV_HOST_URL empty ( ``export SRV_HOST_URL=""`` ), and start the PHP development server with:
 
@@ -120,9 +119,9 @@ The server will bind to: ``$SRV_HOST_NAME:$SRV_HOST_PORT``.
   The names of suites are found in the ``tests/acceptance/config/behat.yml`` file, and start with ``webUI``.
 
   The tests need to be run as the same user who is running the webserver and this user must be also owner of the config file (``config/config.php``).
-  To run the tests as user that is different to your current terminal user use ``sudo -E -u <username>`` e.g. to run as 'www-data' user ``sudo -E -u www-data bash tests/travis/start_ui_tests.sh``.
+  To run the tests as a user that is different to your current terminal user run ``sudo -E -u <username>``. For example, to execute the script as as ``www-data``, run ``sudo -E -u www-data bash tests/travis/start_ui_tests.sh``.
 
-- The browser for the tests runs inside the selenium docker container. View it by running the ``vnc`` viewer:
+- The browser for the tests runs inside the Selenium docker container. View it by running the ``vnc`` viewer:
 
   .. code-block:: console
 
@@ -138,12 +137,12 @@ The test system must have (at least locally) functioning IPv6:
 - working loopback address ::1
 - a "real" routable IPv6 address (not just a link-local address)
 
-If you have a server set up that listens on both IPv4 and IPv6 (e.g. localhost on 127.0.0.1 and ::1) 
-then the UI tests will access the server via whichever protocol your operating system prefers. 
-If there are tests that specifically specify IPv4 or IPv6, then those will choose a suitable local 
+If you have a server set up that listens on both IPv4 and IPv6 (e.g. localhost on 127.0.0.1 and ::1)
+then the UI tests will access the server via whichever protocol your operating system prefers.
+If there are tests that specifically specify IPv4 or IPv6, then those will choose a suitable local
 address to come from so that they access the server using the required IP version.
 
-If you are using the PHP dev server, then before starting it, in addition to the exports in the Set Up Test section, 
+If you are using the PHP dev server, then before starting it, in addition to the exports in the Set Up Test section,
 specify where the IPv6 server should listen:
 
 .. code-block:: console
@@ -164,8 +163,8 @@ and an IPv4 name or address for ``IPV4_HOST_NAME``:
   export SRV_HOST_NAME=ip6-localhost
   export IPV4_HOST_NAME=localhost
 
-Because not everyone will have functional IPv6 on their test system yet, tests that specifically 
-require IPv6 are tagged ``@skip @ipv6``. To run those tests, follow the section below on running 
+Because not everyone will have functional IPv6 on their test system yet, tests that specifically
+require IPv6 are tagged ``@skip @ipv6``. To run those tests, follow the section below on running
 skipped tests and specify ``--tags @ipv6``.
 
 Running UI Tests for One Feature
@@ -210,7 +209,7 @@ Skip a test by tagging it ``@skip`` and then put another tag with text that desc
   Scenario Outline: change quota to an invalid value
 
 Skipped tests are listed at the end of a default UI test run.
-You can locally run the skipped test(s). 
+You can locally run the skipped test(s).
 Run all skipped tests with:
 
 .. code-block:: console
@@ -228,15 +227,17 @@ When fixing the bug, remove these skip tags in the PR along with the bug fix cod
 Additional Command Options
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Running all suites in a single run is not recommended. It will take more than 1 hour on a typical development system.
+Running all test suites in a single run is not recommended.
+It will take more than 1 hour on a typical development system.
 However, you may run all UI tests with:
 
 .. code-block:: console
 
    bash tests/travis/start_ui_tests.sh --all-suites
 
-By default, any test scenarios that fail are automatically rerun once each. This minimizes transient failures caused by
-browser and selenium driver timing issues. When developing tests it can be convenient to override this behavior.
+By default, any test scenarios that fail are automatically rerun once.
+This minimizes transient failures caused by browser and Selenium driver timing issues.
+When developing tests it can be convenient to override this behavior.
 To not rerun failed test scenarios:
 
 .. code-block:: console
@@ -246,7 +247,8 @@ To not rerun failed test scenarios:
 Local Selenium Setup
 ~~~~~~~~~~~~~~~~~~~~
 
-You may optionally run the ``selenium`` server locally. ``docker`` is now the recommended way, but local ``selenium`` is also possible:
+You may optionally run the Selenium server locally.
+Docker is now the recommended way, but local Selenium is also possible:
 
 - `Selenium standalone server <http://docs.seleniumhq.org/download/>`_ e.g. version 3.12.0 or newer.
 - Browser installed that you would like to test on (e.g. chrome)
@@ -258,15 +260,23 @@ You may optionally run the ``selenium`` server locally. ``docker`` is now the re
 
     java -jar selenium-server-standalone-3.12.0.jar -port 4445 -enablePassThrough false
 
-- In this configuration, the tests will keep popping open the browser-under-test on your local system.
+- In this configuration, the tests will continually open the browser-under-test on your local system.
 
-- If you run any test scenarios that need ``mailhog`` (to test password reset etc.), then you need to run the ``mailhog`` ``docker`` container. That is much simpler than trying to configure ``mailhog`` on your local system.
+- If you run any test scenarios that need MailHog (to test password reset etc.), then you need to run the MailHog Docker container. That is much simpler than trying to configure MailHog on your local system.
 
 Known Issues
 ~~~~~~~~~~~~
 - Tests that are known not to work in specific browsers are tagged e.g. ``@skipOnFIREFOX47+`` or ``@skipOnINTERNETEXPLORER`` and will be skipped by the script automatically
 
-- The web driver for the current version of Firefox works differently to the old one. If you want to test FF < 56 you need to test on 47.0.2 and to use selenium server 2.53.1 for it
+- The web driver for the current version of Firefox works differently to the old one. If you want to test FF < 56 you need to test on 47.0.2 and to use Selenium server 2.53.1 for it
 
-  - `Download and install version 47.0.2 of Firefox <https://ftp.mozilla.org/pub/firefox/releases/47.0.2/>`_. 
+  - `Download and install version 47.0.2 of Firefox <https://ftp.mozilla.org/pub/firefox/releases/47.0.2/>`_.
   - `Download version 2.53.2 of the Selenium web driver <https://selenium-release.storage.googleapis.com/index.html?path=2.53/>`_.
+
+.. Links
+
+.. _Docker CE Installed: https://docs.docker.com/install/linux/docker-ce/ubuntu/
+.. _Docker Post-install: https://docs.docker.com/install/linux/linux-postinstall/
+.. _ufw: https://help.ubuntu.com/community/UFW
+.. _MailHog: https://github.com/mailhog/MailHog
+.. _Selenium server: https://www.seleniumhq.org


### PR DESCRIPTION
Issue #4159 

Now that we use ```docker``` in ```drone``` for the UI  tests, actually it is easier and cleaner for devs and QA people to use ``docker`` locally to run the necessary ```selenium`` ```mailhog`` etc pieces when running webUI tests.