### PR TITLE
Add semicolons to the end of mysql commands

### DIFF
--- a/developer_manual/core/unit-testing.rst
+++ b/developer_manual/core/unit-testing.rst
@@ -68,7 +68,7 @@ You can find more information in `the PHPUnit documentation`_.
 Running PHP Unit tests for ownCloud >= 10.0
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-There are existing tests provided by ownCoud which are ready to run.
+There are existing tests provided by ownCloud which are ready to run.
 
 - Change into ``webroot`` and run ``make help`` to see tests and parameters available.
 
@@ -179,18 +179,18 @@ MySQL Setup
 
 ::
 
-  CREATE DATABASE oc_autotest
-  CREATE USER 'oc_autotest'@'localhost' IDENTIFIED BY 'owncloud'
-  GRANT ALL ON oc_autotest.* TO 'oc_autotest'@'localhost'
+  CREATE DATABASE oc_autotest;
+  CREATE USER 'oc_autotest'@'localhost' IDENTIFIED BY 'owncloud';
+  GRANT ALL ON oc_autotest.* TO 'oc_autotest'@'localhost';
 
 For parallel executor support with EXECUTOR_NUMBER=0 
 _____________________________________________________
 
 ::
 
-  CREATE DATABASE oc_autotest0
-  CREATE USER 'oc_autotest0'@'localhost' IDENTIFIED BY 'owncloud'
-  GRANT ALL ON oc_autotest0.* TO 'oc_autotest0'@'localhost'
+  CREATE DATABASE oc_autotest0;
+  CREATE USER 'oc_autotest0'@'localhost' IDENTIFIED BY 'owncloud';
+  GRANT ALL ON oc_autotest0.* TO 'oc_autotest0'@'localhost';
 
 PostgreSQL Setup
 ^^^^^^^^^^^^^^^^


### PR DESCRIPTION
I  was setting this up on a new computer this morning, cut-pasting the ``CREATE DATABASE`` etc mySQL commands. It is handy if the ``;`` needed on the end of the command is there already.

And fix a random typo ``ownCoud``