### PR TITLE
Update the minimum PHP version requirements

### DIFF
--- a/admin_manual/installation/source_installation.rst
+++ b/admin_manual/installation/source_installation.rst
@@ -47,7 +47,7 @@ Required
 PHP Version
 ~~~~~~~~~~~
 
-PHP >= 5.6 (ideally 7.0 or above)
+PHP (5.6+, 7.0, & 7.1)
 
 PHP Extensions
 ~~~~~~~~~~~~~~

--- a/admin_manual/installation/source_installation.rst
+++ b/admin_manual/installation/source_installation.rst
@@ -49,6 +49,11 @@ PHP Version
 
 PHP (5.6+, 7.0, & 7.1)
 
+.. WARNING::
+
+   ownCloud recommends the use of PHP 7.1 in new installations.
+   Sites using a version earlier than PHP 7.1 are *strongly encouraged* to migrate to PHP 7.1
+
 PHP Extensions
 ~~~~~~~~~~~~~~
 

--- a/admin_manual/installation/system_requirements.rst
+++ b/admin_manual/installation/system_requirements.rst
@@ -18,7 +18,7 @@ Operating System  Ubuntu 16.04, 17.04 and 17.10; Debian 7, 8 and 9; SUSE Linux E
                   Fedora 26, 27 and 28; open Suse Tumbleweed and Leap 42.1, 42.2, 42.3
 Database          MySQL or MariaDB 5.5+, Oracle 11g, PostgreSQL, & SQLite
 Web server        Apache 2.4 with ``prefork`` :ref:`apache-mpm-label` and ``mod_php``
-PHP Runtime       PHP 7.1
+PHP Runtime       PHP (5.6+, 7.0, & 7.1)
 ================= =================================================================================
 
 .. important:: 

--- a/admin_manual/installation/system_requirements.rst
+++ b/admin_manual/installation/system_requirements.rst
@@ -18,7 +18,7 @@ Operating System  Ubuntu 16.04, 17.04 and 17.10; Debian 7, 8 and 9; SUSE Linux E
                   Fedora 26, 27 and 28; open Suse Tumbleweed and Leap 42.1, 42.2, 42.3
 Database          MySQL or MariaDB 5.5+, Oracle 11g, PostgreSQL, & SQLite
 Web server        Apache 2.4 with ``prefork`` :ref:`apache-mpm-label` and ``mod_php``
-PHP Runtime       PHP (5.6+, 7.0, & 7.1)
+PHP Runtime       PHP 7.1
 ================= =================================================================================
 
 .. important:: 
@@ -27,7 +27,6 @@ PHP Runtime       PHP (5.6+, 7.0, & 7.1)
     If you use Ubuntu 16.04:
 
     - PHP 7.1 is only available via ppa. To add a ppa to your system, use this command: ``sudo add-apt-repository ppa:user/ppa-name``.
-    - PHP 7.2 standard installable, but you have to install some mandatory modules yourself, like `intl`_.
 
 .. note::
    


### PR DESCRIPTION
Set PHP 7.1 as the minimum PHP version required, and remove reference to PHP 7.2. Fixes #4194.