### PR TITLE
System requirements for 10.0.9

### DIFF
--- a/admin_manual/installation/system_requirements.rst
+++ b/admin_manual/installation/system_requirements.rst
@@ -13,9 +13,9 @@ Server
 ================= =================================================================================
 Platform          Options
 ================= =================================================================================
-Operating System  Ubuntu 16.04, 17.04 and 17.10; Debian 7, 8 and 9; SUSE Linux Enterprise Server 12 
-                  with SP1, SP2 and SP3; Red Hat Enterprise Linux/Centos 6.9, 7.3 and 7.4;
-                  Fedora 26, 27 and 28; open Suse Tumbleweed and Leap 42.1, 42.2, 42.3
+Operating System  Ubuntu 16.04 and 18.04; Debian 8 and 9; SUSE Linux Enterprise Server 12
+                  with SP1, SP2 and SP3; Red Hat Enterprise Linux/Centos 6.9, 7.3, 7.4 and 7.5;
+                  Fedora 27 and 28; open Suse Tumbleweed and Leap 42.3
 Database          MySQL or MariaDB 5.5+, Oracle 11g, PostgreSQL, & SQLite
 Web server        Apache 2.4 with ``prefork`` :ref:`apache-mpm-label` and ``mod_php``
 PHP Runtime       PHP (5.6+, 7.0, & 7.1)
@@ -29,7 +29,8 @@ PHP Runtime       PHP (5.6+, 7.0, & 7.1)
     - PHP 7.1 is only available via ppa. To add a ppa to your system, use this command: ``sudo add-apt-repository ppa:user/ppa-name``.
 
 .. note::
-   
+
+   - Ubuntu 18.04 ships with PHP 7.2. For production use, install PHP 7.1
    - Red Hat Enterprise Linux & Centos 7 are 64-bit only.
    - Oracle 11g is only supported for the Enterprise edition.
    - SQLite is not encouraged for production use.
@@ -46,7 +47,7 @@ Web Browser
 - Edge (current version on Windows 10)
 - IE11+ (except Compatibility Mode)
 - Firefox 57+ or 52 ESR
-- Chrome 64+
+- Chrome 66+
 - Safari 10+
 
 Hypervisors 
@@ -63,10 +64,10 @@ Desktop
 - Windows 7+
 - Mac OS X 10.7+ (**64-bit only**)
 - CentOS 6 & 7 (64-bit only)
-- Debian 7.0 & 8.0 & 9.0
-- Fedora 26 & 27
-- Ubuntu 16.04 & 17.04 & 17.10
-- openSUSE Leap 42.2 & 42.3
+- Debian 8.0 & 9.0
+- Fedora 27 & 28
+- Ubuntu 16.04 & 18.04
+- openSUSE Leap 42.3
 
 .. note::
    For Linux distributions, we support, if technically feasible, the latest 2 versions per platform and the previous `LTS`_.

--- a/admin_manual/installation/system_requirements.rst
+++ b/admin_manual/installation/system_requirements.rst
@@ -30,6 +30,16 @@ Server
 | PHP Runtime      | - 5.6+, 7.0, & 7.1                                                    |
 +------------------+-----------------------------------------------------------------------+
 
+.. Distribution Release Schedules
+
+.. - Debian: https://wiki.debian.org/DebianReleases
+.. - Ubuntu: https://www.ubuntu.com/info/release-end-of-life
+.. - Fedora: https://fedoraproject.org/wiki/End_of_life & https://fedoraproject.org/wiki/Releases
+.. - openSUSE: https://en.opensuse.org/Lifetime
+.. - Red Hat / Fedora: https://access.redhat.com/articles/3078
+.. - SUSE: https://www.suse.com/releasenotes/
+.. - Mozilla: https://wiki.mozilla.org/Release_Management/Calendar
+
 .. important::
 
     For the future release of ownCloud 10.1, a minimum php version of 7.1 is needed.
@@ -116,3 +126,4 @@ The following are currently required if you're running ownCloud together with a 
 
 .. _LTS: https://wiki.ubuntu.com/LTS
 .. _intl: http://php.net/manual/en/intro.intl.php
+

--- a/admin_manual/installation/system_requirements.rst
+++ b/admin_manual/installation/system_requirements.rst
@@ -10,18 +10,27 @@ For *best performance*, *stability*, *support*, and *full functionality* we offi
 Server
 ^^^^^^
 
-================= =================================================================================
-Platform          Options
-================= =================================================================================
-Operating System  Ubuntu 16.04 and 18.04; Debian 8 and 9; SUSE Linux Enterprise Server 12
-                  with SP1, SP2 and SP3; Red Hat Enterprise Linux/Centos 6.9, 7.3, 7.4 and 7.5;
-                  Fedora 27 and 28; open Suse Tumbleweed and Leap 42.3
-Database          MySQL or MariaDB 5.5+, Oracle 11g, PostgreSQL, & SQLite
-Web server        Apache 2.4 with ``prefork`` :ref:`apache-mpm-label` and ``mod_php``
-PHP Runtime       PHP (5.6+, 7.0, & 7.1)
-================= =================================================================================
++------------------+-----------------------------------------------------------------------+
+| Platform         | Options                                                               |
++==================+=======================================================================+
+| Operating System | - Ubuntu 16.04 and 18.04                                              |
+|                  | - Debian 7, 8, and 8                                                  |
+|                  | - Red Hat Enterprise Linux/Centos 6.9, 7.3, 7.4, and 7.5              |
+|                  | - Fedora 26, 27 and 28                                                |
+|                  | - SUSE Linux Enterprise Server 12 with SP1, SP2 and SP3               |
+|                  | - openSUSE Tumbleweed and Leap 42.1, 42.2, 42.3                       |
++------------------+-----------------------------------------------------------------------+
+| Database         | - MySQL or MariaDB 5.5+                                               |
+|                  | - Oracle 11g                                                          |
+|                  | - PostgreSQL                                                          |
+|                  | - SQLite                                                              |
++------------------+-----------------------------------------------------------------------+
+| Web server       | - Apache 2.4 with ``prefork`` :ref:`apache-mpm-label` and ``mod_php`` |
++------------------+-----------------------------------------------------------------------+
+| PHP Runtime      | - 5.6+, 7.0, & 7.1                                                    |
++------------------+-----------------------------------------------------------------------+
 
-.. important:: 
+.. important::
 
     For the future release of ownCloud 10.1, a minimum php version of 7.1 is needed.
     If you use Ubuntu 16.04:
@@ -35,13 +44,13 @@ PHP Runtime       PHP (5.6+, 7.0, & 7.1)
    - Oracle 11g is only supported for the Enterprise edition.
    - SQLite is not encouraged for production use.
 
-Mobile 
+Mobile
 ^^^^^^
 
 - iOS 9.0+
 - Android 4.0+
 
-Web Browser 
+Web Browser
 ^^^^^^^^^^^
 
 - Edge (current version on Windows 10)
@@ -50,7 +59,7 @@ Web Browser
 - Chrome 66+
 - Safari 10+
 
-Hypervisors 
+Hypervisors
 ^^^^^^^^^^^
 
 - Hyper-V
@@ -75,23 +84,23 @@ Desktop
 Alternative (But Unsupported) Options
 -------------------------------------
 
-If you are not able to use one or more of the above tools, the following options are also available. 
+If you are not able to use one or more of the above tools, the following options are also available.
 
 Web Server
 ^^^^^^^^^^
 
-- NGINX with PHP-FPM 
+- NGINX with PHP-FPM
 
 Memory Requirements
 -------------------
 
 Memory requirements for running an ownCloud server are greatly variable,
 depending on the numbers of users and files, and volume of server activity.
-ownCloud officially requires a minimum of 128MB RAM. But, we recommend a minimum of 512MB. 
+ownCloud officially requires a minimum of 128MB RAM. But, we recommend a minimum of 512MB.
 
 .. note:: *Consideration for low memory environments*
-   
-  Scanning of files is committed internally in 10k files chunks. 
+
+  Scanning of files is committed internally in 10k files chunks.
   Based on tests, server memory usage for scanning greater than 10k files uses about 75MB of additional memory.
 
 Database Requirements
@@ -104,6 +113,6 @@ The following are currently required if you're running ownCloud together with a 
 * "READ COMMITED" transaction isolation level (See: :ref:`db-transaction-label`)
 
 .. Links
-   
+
 .. _LTS: https://wiki.ubuntu.com/LTS
 .. _intl: http://php.net/manual/en/intro.intl.php


### PR DESCRIPTION
I was checking current browser versions, and remembered Ubuntu 18.04 and so thought I would check the other OS versions.
https://wiki.debian.org/DebianReleases
Debian 7 end of LTS was May 2018

https://www.ubuntu.com/info/release-end-of-life
Ubuntu 17.* is gone
Ubuntu 18.04 ships with PHP7.2 as default

https://fedoraproject.org/wiki/End_of_life
Fedora 26 EOL 2018-05-29

https://fedoraproject.org/wiki/Releases
Fedora 27 and 28 are the current releases in support

https://en.opensuse.org/Lifetime
openSUSE Leap 42.2 EOL Jan 26 2018
openSUSE Leap 42.1 EOL May 17 2017

https://access.redhat.com/articles/3078
RedHat releases - 7.5 2018-04-10 new recent release

https://www.suse.com/releasenotes/
SUSE 12 SP1 SP2 SP3 current

https://wiki.mozilla.org/Release_Management/Calendar
Firefox versions OK (52ESR is still current for a  few more months)

Chrome is up to v67 - so support is for latest-1 also.


