### PR TITLE
Use public URL for submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "_shared_assets"]
 	path = _shared_assets
-	url = git@github.com:owncloud/docs-themes.git
+	url = https://github.com/owncloud/docs-themes.git


### PR DESCRIPTION
Needed to make anonymous clones + submodule checkout work, required by release script.

Without this, one needs to configure Github account + keys to be able to check out the submodule.
