### PR TITLE
[stable10] Use public URL for submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "_shared_assets"]
 	path = _shared_assets
-	url = git@github.com:owncloud/docs-themes.git
+	url = https://github.com/owncloud/docs-themes.git


### PR DESCRIPTION
Backport of https://github.com/owncloud/documentation/pull/4209