### PR TITLE
Name affected keys for overwritecondaddr

### DIFF
--- a/admin_manual/configuration/server/config_sample_php_parameters.rst
+++ b/admin_manual/configuration/server/config_sample_php_parameters.rst
@@ -491,7 +491,9 @@ URLs.
 	'overwritecondaddr' => '',
 
 This option allows you to define a manual override condition as a regular
-expression for the remote IP address. For example, defining a range of IP
+expression for the remote IP address. The keys ``overwritewebroot``,
+``overwriteprotocol``, and ``overwritehost`` are subject to this condition.
+For example, defining a range of IP
 addresses starting with ``10.0.0.`` and ending with 1 to 3:
 ``^10\.0\.0\.[1-3]$``
 


### PR DESCRIPTION
Please also check the php code in https://github.com/owncloud/core/blob/master/lib/private/AppFramework/Http/Request.php#L544

That trailing `|| $type !== 'protocol';`gives me a headache.