### PR TITLE
added fingerprint command after restore

### DIFF
--- a/admin_manual/maintenance/restore.rst
+++ b/admin_manual/maintenance/restore.rst
@@ -37,7 +37,10 @@ MySQL
 
 MySQL is the recommended database engine. To restore MySQL::
 
+    occ maintenance:mode --on 
     mysql -h [server] -u [username] -p[password] [db_name] < owncloud-dbbackup.bak
+    occ maintenance:data-fingerprint
+    occ maintenance:mode --off
 
 SQLite
 ^^^^^^


### PR DESCRIPTION
after restoring the database, we advise to run the fingerprint command, to tell desktop and mobile clients that a server backup has been restored. Users will be prompted to resolve any conflicts between newer and older file versions.