### PR TITLE
added new features in custom groups

### DIFF
--- a/user_manual/files/webgui/custom_groups.rst
+++ b/user_manual/files/webgui/custom_groups.rst
@@ -10,7 +10,7 @@ To address that, as of ownCloud 10.0, you can now create your own groups on-the-
 Here's how to use it. 
 
 .. note::
-   	- creating a customgroup with existing display name displays an error
+   	- creating a customgroup with an existing display name displays an error
 	- renaming a customgroup to an existing display name displays an error
 	- a config switch (checkbox) makes it possible to allow duplicates (defaults to "allow")
 

--- a/user_manual/files/webgui/custom_groups.rst
+++ b/user_manual/files/webgui/custom_groups.rst
@@ -12,8 +12,8 @@ Here's how to use it.
 .. note::
 	Depending on your custom groups setting, configured by the ownCloud admin, custom groups may behave differently
 	
-	- creating or renaming a custom group using an existing display name will show an error
-	- a config switch in the ownCloud's admin settings (checkbox) makes it possible to allow multiple custom groups with the same name
+	- Creating or renaming a custom group using an existing display name will show an error
+	- A config switch (checkbox) makes it possible to allow multiple custom groups with the same name
 	- Custom group creation can be limited to the ownCloud **group admins**
 
 Creating Custom Groups

--- a/user_manual/files/webgui/custom_groups.rst
+++ b/user_manual/files/webgui/custom_groups.rst
@@ -12,7 +12,7 @@ Here's how to use it.
 .. note::
 	Depending on your Custom Groups setting, configured by the ownCloud admin, Custom Groups may behave differently
 	- Creating or renaming a Custom Group using an existing name of another Custom Group can be allowed or not depending on administrative settings.
-	- Custom Group creation can be limited to the ownCloud **group admins**
+	- Custom Group creation can be limited to ownCloud **group admins**
 
 Creating Custom Groups
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/user_manual/files/webgui/custom_groups.rst
+++ b/user_manual/files/webgui/custom_groups.rst
@@ -10,11 +10,9 @@ To address that, as of ownCloud 10.0, you can now create your own groups on-the-
 Here's how to use it. 
 
 .. note::
-	Depending on your custom groups setting, configured by the ownCloud admin, custom groups may behave differently
-	
-	- Creating or renaming a custom group using an existing display name will show an error
-	- A config switch (checkbox) makes it possible to allow multiple custom groups with the same name
-	- Custom group creation can be limited to the ownCloud **group admins**
+	Depending on your Custom Groups setting, configured by the ownCloud admin, Custom Groups may behave differently
+	- Creating or renaming a Custom Group using an existing name of another Custom Group can be allowed or not depending on administrative settings.
+	- Custom Group creation can be limited to the ownCloud **group admins**
 
 Creating Custom Groups
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/user_manual/files/webgui/custom_groups.rst
+++ b/user_manual/files/webgui/custom_groups.rst
@@ -10,8 +10,11 @@ To address that, as of ownCloud 10.0, you can now create your own groups on-the-
 Here's how to use it. 
 
 .. note::
-   	- creating or renaming a custom group using an existing display name will show an error.
-	- a config switch (checkbox) makes it possible to allow duplicates (defaults to "allow").
+	Depending on your custom groups setting, configured by the ownCloud admin, custom groups may behave differently
+	
+	- creating or renaming a custom group using an existing display name will show an error
+	- a config switch in the ownCloud's admin settings (checkbox) makes it possible to allow multiple custom groups with the same name
+	- Custom group creation can be limited to the ownCloud **group admins**
 
 Creating Custom Groups
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/user_manual/files/webgui/custom_groups.rst
+++ b/user_manual/files/webgui/custom_groups.rst
@@ -9,6 +9,11 @@ This wasn't the most efficient way to work.
 To address that, as of ownCloud 10.0, you can now create your own groups on-the-fly, through a feature called "Custom Groups". 
 Here's how to use it. 
 
+.. note::
+   	- creating a customgroup with existing display name displays an error
+	- renaming a customgroup to an existing display name displays an error
+	- a config switch (checkbox) makes it possible to allow duplicates (defaults to "allow")
+
 Creating Custom Groups
 ~~~~~~~~~~~~~~~~~~~~~~
 
@@ -62,7 +67,6 @@ Change the name and click enter, and the name will be changed.
 
 .. image:: ../../images/custom-groups/rename-custom-group.png
    :alt: Rename a custom group
-
 
  
 .. Links

--- a/user_manual/files/webgui/custom_groups.rst
+++ b/user_manual/files/webgui/custom_groups.rst
@@ -10,9 +10,8 @@ To address that, as of ownCloud 10.0, you can now create your own groups on-the-
 Here's how to use it. 
 
 .. note::
-   	- creating a customgroup with an existing display name displays an error
-	- renaming a customgroup to an existing display name displays an error
-	- a config switch (checkbox) makes it possible to allow duplicates (defaults to "allow")
+   	- creating or renaming a custom group using an existing display name will show an error.
+	- a config switch (checkbox) makes it possible to allow duplicates (defaults to "allow").
 
 Creating Custom Groups
 ~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
because of https://github.com/owncloud/documentation/issues/3289

https://doc.owncloud.com/server/10.0/user_manual/files/webgui/custom_groups.html?highlight=custom%20groups

Some things will change with the upcoming release of the app. See here: owncloud/enterprise#2092 (comment)

Please add that to the docs.

Apart from that please add a hint (if not yet included, I just skimmed quickly :) ) that ownCloud admins can see all custom groups of an instance and have group admin privileges for those.

Thanks!

and https://github.com/owncloud/enterprise/issues/2092#issuecomment-321470519

PR was merged, will be released with the next version of customgroups.

It contains the following:

creating a customgroup with existing display name displays an error
renaming a customgroup to an existing display name displays an error
a config switch (checkbox) makes it possible to allow duplicates (defaults to "allow")
