### PR TITLE
addional info added

### DIFF
--- a/admin_manual/appliance/Clamav.rst
+++ b/admin_manual/appliance/Clamav.rst
@@ -78,10 +78,9 @@ If you want to refresh the ClamAV database manually, follow these steps:
   # Start the refresh process again with this command:
   sudo freshclam
 
-..note::
+..warning::
 
-	- When the app is just enabled (without configuration or with wrong configuration) it will strictly reject **all** uploads for the whole instance.
-	- Configuration can be done via occ `config:app:set files_antivirus whatever_key value` to circumvent this issue.
+  When the app is enabled — but is not configured or has an incorrect configuration — it will reject **all** uploads for the entire instance. To avoid this situation, use ``sudo -u www-data php occ config:app:set files_antivirus whatever_key value`` to configure the app correctly.
 
 .. Links
 

--- a/admin_manual/appliance/Clamav.rst
+++ b/admin_manual/appliance/Clamav.rst
@@ -78,6 +78,11 @@ If you want to refresh the ClamAV database manually, follow these steps:
   # Start the refresh process again with this command:
   sudo freshclam
 
+..note::
+
+	- When the app is just enabled (without configuration or with wrong configuration) it will strictly reject all uploads for the whole instance.
+	- Configuration can be done via occ config:app:set files_antivirus whatever_key value to circumvent this issue
+
 .. Links
 
 .. _freshclam: https://linux.die.net/man/1/freshclam

--- a/admin_manual/appliance/Clamav.rst
+++ b/admin_manual/appliance/Clamav.rst
@@ -80,8 +80,8 @@ If you want to refresh the ClamAV database manually, follow these steps:
 
 ..note::
 
-	- When the app is just enabled (without configuration or with wrong configuration) it will strictly reject all uploads for the whole instance.
-	- Configuration can be done via occ config:app:set files_antivirus whatever_key value to circumvent this issue
+	- When the app is just enabled (without configuration or with wrong configuration) it will strictly reject **all** uploads for the whole instance.
+	- Configuration can be done via occ `config:app:set files_antivirus whatever_key value` to circumvent this issue.
 
 .. Links
 


### PR DESCRIPTION
https://github.com/owncloud/documentation/issues/3298#issuecomment-394714462

Need to add some more info about functional changes

owncloud/files_antivirus#181

When the app is just enabled (without configuration or with wrong configuration) it will strictly reject all uploads for the whole instance

Configuration can be done via occ config:app:set files_antivirus whatever_key value to circumvent this issue