### PR TITLE
Improving app management: script for moving apps to an alternative location

### DIFF
--- a/admin_manual/installation/apps_management_installation.rst
+++ b/admin_manual/installation/apps_management_installation.rst
@@ -56,7 +56,7 @@ These are:
 #. It eases manual upgrades. Downloaded apps must be manually copied. Having them in a separate directory makes it simpler to manage.
 #. ownCloud may gain new core apps in newer versions. Doing so orphans deprecated apps, but doesn't remove them.
 
-If you want to store apps in a custom directory, instead of ownCloud's default (``/app``), you need to modify the ``apps_paths`` element in ``config/config.php``.
+If you want to store apps in a custom directory, instead of ownCloud's default (``/app``), you need to modify the ``apps_paths`` key in ``config/config.php``.
 There, you need to add a new associative array that contains three elements.
 These are:
 
@@ -71,13 +71,19 @@ The configuration example below shows how to add a second directory, called ``ap
    :emphasize-lines: 9-13
 
 After you add a new directory configuration, you can then move apps from the original app directory to the new one. 
-To do so, follow these steps:
+If you want to identify as an example all non core / non shipped apps, use the following command:
+
+::
+
+  sudo -uwww-data ./occ app:list --shipped=false
+
+Follow these steps to manually move apps:
 
 #. :ref:`Enable maintenance mode <maintenance_commands_label>`.
 #. :ref:`Disable the apps <apps_commands_label>` that you want to move.
-#. Create a new apps directory and assign it the same user and group, and ownership permissions as the core apps directory.
+#. Create a new apps directory like ``apps-external`` and assign it the same user, group and ownership permissions as the core apps directory.
 #. Move the apps from the old apps directory to the new apps directory.
-#. Add a new app directory in ``config/config.php``.
+#. Add the key for the new app directory in ``config/config.php``.
 #. If you're using a cache, such as `Redis <../configuration/server/caching_configuration.html#clearing-the-redis-cache>`_ or `Memcached <../configuration/server/caching_configuration.html#clearing-the-memcached-cache>`_, ensure that you clear the cache.
 #. Re-enable the apps.
 #. Disable maintenance mode.
@@ -85,20 +91,39 @@ To do so, follow these steps:
 Script for moving non core apps in custom app directories
 ---------------------------------------------------------
 
-If you want to move your non core / non shipped apps in a custom app directory, to keep your installation clean, here is a script you can use.
+In the same way as you can manually move eg non core / non shipped apps to a custom directory, a script
+might automate and help in this task.
 
-You will need to create a second apps folder and call it something.
+Follow these steps to automate moving apps:
 
-In this example we called it `apps2`.
+#. :ref:`Enable maintenance mode <maintenance_commands_label>`.
+#. :ref:`Disable the apps <apps_commands_label>` that you want to move.
+#. Create a new apps directory like ``apps-external`` and assign it the same user, group and ownership permissions as the core apps directory.
+#. Run the script described below in your ownCloud directory.
+#. Add the key for the new app directory in ``config/config.php``.
+#. If you're using a cache, such as `Redis <../configuration/server/caching_configuration.html#clearing-the-redis-cache>`_ or `Memcached <../configuration/server/caching_configuration.html#clearing-the-memcached-cache>`_, ensure that you clear the cache.
+#. Re-enable the apps.
+#. Disable maintenance mode.
+
+As preparation, please install the ``jq`` library. 
+``jq`` is like sed for JSON data - you can use it to slice, filter, map and transform structured data.
+
+
+To install ``jq`` run the following command:
 
 ::
 
-	# first you need to install jq 
-	apt install -y jq
-	# then move the apps
-	for app in $(sudo -u www-data ./occ app:list --shipped=false --output=json | jq '.enabled, .disabled' | jq -r 'keys[]'); do
-  	sudo -u www-data mv apps/${app} apps2/${app}
-	done
+  apt install -y jq
+
+Script to move all non core / non shipped apps to the custom folder ``apps-external``:
+
+::
+
+  #!/bin/bash
+  
+  for app in $(sudo -u www-data ./occ app:list --shipped=false --output=json | jq '.enabled, .disabled' | jq -r 'keys[]'); do
+  sudo -u www-data mv apps/${app} apps-external/${app}
+  done
 
 Manually Installing Apps
 ------------------------

--- a/admin_manual/installation/apps_management_installation.rst
+++ b/admin_manual/installation/apps_management_installation.rst
@@ -108,7 +108,7 @@ In preparation, please install the ``jq`` library.
 jq is like sed for JSON data - you can use it to slice, filter, map and transform structured data.
 
 
-To install ``jq`` run the following command:
+To install jq <http://https://stedolan.github.io/jq/> run the following command:
 
 ::
 

--- a/admin_manual/installation/apps_management_installation.rst
+++ b/admin_manual/installation/apps_management_installation.rst
@@ -82,6 +82,24 @@ To do so, follow these steps:
 #. Re-enable the apps.
 #. Disable maintenance mode.
 
+Script for moving non core apps in custom app directories
+---------------------------------------------------------
+
+If you want to move your non core / non shipped apps in a custom app directory, to keep your installation clean, here is a script you can use.
+
+You will need to create a second apps folder and call it something.
+
+In this example we called it `apps2`.
+
+::
+
+	# first you need to install jq 
+	apt install -y jq
+	# then move the apps
+	for app in $(sudo -u www-data ./occ app:list --shipped=false --output=json | jq .enabled | jq -r keys[]); do
+  	sudo -u www-data mv apps/${app} apps2/${app}
+	done
+
 Manually Installing Apps
 ------------------------
 

--- a/admin_manual/installation/apps_management_installation.rst
+++ b/admin_manual/installation/apps_management_installation.rst
@@ -71,28 +71,27 @@ The configuration example below shows how to add a second directory, called ``ap
    :emphasize-lines: 9-13
 
 After you add a new directory configuration, you can then move apps from the original app directory to the new one. 
-If you want to identify as an example all non core / non shipped apps, use the following command:
+If you want to identify, as an example, all non-core or non-shipped apps, use the following command:
 
 ::
 
-  sudo -uwww-data ./occ app:list --shipped=false
+  sudo -u www-data php occ app:list --shipped=false
 
 Follow these steps to manually move apps:
 
 #. :ref:`Enable maintenance mode <maintenance_commands_label>`.
 #. :ref:`Disable the apps <apps_commands_label>` that you want to move.
-#. Create a new apps directory like ``apps-external`` and assign it the same user, group and ownership permissions as the core apps directory.
+#. Create a new apps directory, like ``apps-external`` and assign it the same user, group and ownership permissions as the core apps directory.
 #. Move the apps from the old apps directory to the new apps directory.
 #. Add the key for the new app directory in ``config/config.php``.
-#. If you're using a cache, such as `Redis <../configuration/server/caching_configuration.html#clearing-the-redis-cache>`_ or `Memcached <../configuration/server/caching_configuration.html#clearing-the-memcached-cache>`_, ensure that you clear the cache.
+#. If you're using a cache, such as `Redis`_ or `Memcached`_, ensure that you clear the cache.
 #. Re-enable the apps.
 #. Disable maintenance mode.
 
 Script for moving non core apps in custom app directories
 ---------------------------------------------------------
 
-In the same way as you can manually move eg non core / non shipped apps to a custom directory, a script
-might automate and help in this task.
+In the same way as you can manually move apps, e.g., non-core or non-shipped, to a custom directory, a script might automate and help in this task.
 
 Follow these steps to automate moving apps:
 
@@ -105,8 +104,8 @@ Follow these steps to automate moving apps:
 #. Re-enable the apps.
 #. Disable maintenance mode.
 
-As preparation, please install the ``jq`` library. 
-``jq`` is like sed for JSON data - you can use it to slice, filter, map and transform structured data.
+In preparation, please install the ``jq`` library. 
+jq is like sed for JSON data - you can use it to slice, filter, map and transform structured data.
 
 
 To install ``jq`` run the following command:
@@ -142,3 +141,5 @@ Using the example below, both the app's name and directory name would be ``youra
 
 .. _the Marketplace: https://marketplace.owncloud.com
 .. _the application's metadata file: https://doc.owncloud.org/server/latest/developer_manual/app/fundamentals/info.html
+.. _Redis: ../configuration/server/caching_configuration.html#clearing-the-redis-cache
+.. _Memcached: ../configuration/server/caching_configuration.html#clearing-the-memcached-cache

--- a/admin_manual/installation/apps_management_installation.rst
+++ b/admin_manual/installation/apps_management_installation.rst
@@ -96,7 +96,7 @@ In this example we called it `apps2`.
 	# first you need to install jq 
 	apt install -y jq
 	# then move the apps
-	for app in $(sudo -u www-data ./occ app:list --shipped=false --output=json | jq .enabled | jq -r keys[]); do
+	for app in $(sudo -u www-data ./occ app:list --shipped=false --output=json | jq '.enabled, .disabled' | jq -r 'keys[]'); do
   	sudo -u www-data mv apps/${app} apps2/${app}
 	done
 


### PR DESCRIPTION
added a script for moving apps in a apps2 directory to keep owncloud installation clean.