### PR TITLE
Improving occ files:scan description for option --path

### DIFF
--- a/admin_manual/configuration/server/occ_command.rst
+++ b/admin_manual/configuration/server/occ_command.rst
@@ -777,6 +777,12 @@ For example:
 
 In the example above, the user_id ``alice`` is determined implicitly from the path component given.
 
+To get a list of scannable mounts for a given user, use following command:
+
+::
+
+  sudo -u www-data php occ files_external:list user_id
+  
 .. note::
   Mounts are only scannable at the point of origin. Scanning of shares including federated shares 
   is not necessary on the receiver side and therefore not possible.


### PR DESCRIPTION
This is a small improvement for the occ files:san command when using the --path option.
The question was, how to get the scannable mounts a user has.
This info was missing and is now described.

Referencing: 
closed: https://github.com/owncloud/core/issues/30641 ([Feature Request] extend ./occ files:scan to list scannable mounts for a given user)

@PVince81 