### PR TITLE
Update the occ maintenance:install example to include the host option

### DIFF
--- a/admin_manual/configuration/server/occ_command.rst
+++ b/admin_manual/configuration/server/occ_command.rst
@@ -2418,9 +2418,11 @@ This example completes the installation:
 ::
 
  cd /var/www/owncloud/
- sudo -u www-data php occ maintenance:install --database 
- "mysql" --database-name "owncloud"  --database-user "root" --database-pass 
- "password" --admin-user "admin" --admin-pass "password" 
+ sudo -u www-data php occ maintenance:install --database "mysql" \
+    --database-name "owncloud" --database-user "root" \
+    --database-pass "password" --database-host "db" \
+    --admin-user "admin" --admin-pass "password"
+
  ownCloud is not installed - only a limited number of commands are available
  ownCloud was successfully installed
 


### PR DESCRIPTION
Whenever I've used the `occ maintenance:install` example from the docs, I've always had to add the `--database-host` option. So, for anyone else having the same issue, I'm updating the example to include it.