### PR TITLE
Script update to example theme download

### DIFF
--- a/developer_manual/scripts/theme-bootstrap.sh
+++ b/developer_manual/scripts/theme-bootstrap.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # theme-bootstrap.sh
-# Invoke this script with one argument, the new theme's name.
-# Written by Dmitry Mayorov <dmitry@owncloud.com> & Matthew Setter <matthew@matthewsetter.com>
+# Invoke this script with two arguments, the new theme's name and the path to ownCloud root.
+# Written by Dmitry Mayorov <dmitry@owncloud.com>,  Matthew Setter <matthew@matthewsetter.com> & Martin Mattel <github@diemattels.at>
 # Copyright (c) ownCloud 2018.
 
 set -e
@@ -12,31 +12,47 @@ function clone_example_theme
 {
   local APP_NAME="$1"
   local INSTALL_BASE_DIR="$2"
-  local DOWNLOAD_FILE=/tmp/master.zip
+  local MAINFILE=master.zip
+  local UNZIPDIR=/tmp
+  local MASTERNAME=theme-example-master
+  local DOWNLOAD_FILE=$UNZIPDIR/$MAINFILE
   local THEME_ARCHIVE_URL=https://github.com/owncloud/theme-example/archive/master.zip
 
+  # check if the app name already exists
   if  [ -d "$INSTALL_BASE_DIR/$APP_NAME" ]
   then
-    echo "The example theme ('$INSTALL_BASE_DIR/$APP_NAME') already exists."
+    echo "An app with name ('$INSTALL_BASE_DIR/$APP_NAME') already exists."
     echo "Please remove or rename it before running this script again."
     return 1
   fi;
 
-  echo "Cloning ownCloud example theme."
-  echo
-
-  [ -e "$DOWNLOAD_FILE" ] && rm "$DOWNLOAD_FILE"
-  wget --output-document=/tmp/master.zip --tries=3 --continue \
-    --timeout=3 --dns-timeout=3 --connect-timeout=3 --read-timeout=3  \
-    "$THEME_ARCHIVE_URL"
-
-  if unzip -t "$DOWNLOAD_FILE" | grep -q "No errors detected in compressed data"
+  # delete an existing downloaded zip file
+  if [ -e "$DOWNLOAD_FILE" ]
   then
-    cd /tmp > /dev/null || return
-    unzip master.zip \
-      && mv /tmp/theme-example-master "$INSTALL_BASE_DIR/$APP_NAME" \
-      && rm "$DOWNLOAD_FILE"
-    cd - > /dev/null || return
+	rm "$DOWNLOAD_FILE"
+  fi
+
+  echo "Downloading ownCloud example theme."
+
+  # getting the exmple theme from git
+  if ! wget --output-document="$DOWNLOAD_FILE" --tries=3 --continue \
+    --timeout=3 --dns-timeout=3 --connect-timeout=3 --read-timeout=3  \
+    "$THEME_ARCHIVE_URL" >/dev/null 2>&1
+  then
+    echo "Download error, exiting"
+    return 1
+  fi
+
+  # first test if unzip would error then extract
+  if unzip -t "$DOWNLOAD_FILE" >/dev/null 2>&1
+  then
+	# unzip with overwriting existing files and directories and supressed output
+	echo "Unzipping download"
+	unzip -oq "$DOWNLOAD_FILE" -d "$UNZIPDIR"
+	echo "Moving to target location"
+    mv "$UNZIPDIR/$MASTERNAME" "$INSTALL_BASE_DIR/$APP_NAME" 
+	echo "Removing download"
+    rm "$DOWNLOAD_FILE" 
   else 
     echo "Cannot complete setup of the ownCloud example theme as it is corrupted."
     return 1
@@ -45,42 +61,72 @@ function clone_example_theme
 
 E_BADARGS=85
 
-# Stores the directory where this script was called from
+# Remembers the directory where this script was called from
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 
+# Check if run as sudo (root), needed for sub script calling and changing file permissions
+if (( $EUID != 0 )); then
+    echo "Please run this script with sudo or as root"
+    exit
+fi
+
+# Check if enough parameters have been applied
 if (( $# != 2 ))
 then
-  echo "Not enough arguments supplied."
-  echo "Usage: $( basename "$0" ) [-v] [-h] [theme id] [owncloud directory]"
+  echo "Not enough arguments provided."
+  echo "Usage: $( basename "$0" ) [new theme name] [owncloud root directory]"
   exit $E_BADARGS
 fi
 
-app_name="$1"
-owncloud_directory="$2"
-apps=$("$SCRIPT_DIR/read-config.php" "$owncloud_directory")
+# Check if read-config.php file exists in the same directory
+if [ ! -f $SCRIPT_DIR/read-config.php ]
+then
+    echo "File read-config.php not found! Must be in the same dir as this script"
+    exit
+fi
 
-OLDPWD=${OLDPWD:=$(pwd)}
+# Check if php file is set to be executable, script will else not work
+if [ ! -x $SCRIPT_DIR/read-config.php ]
+then
+    echo "File read-config.php is not set executable"
+    exit
+fi
+
+app_name="$1"
+owncloud_root="$2"
+apps=$(php "$SCRIPT_DIR/read-config.php" "$owncloud_root")
+
+# Check if the php script returned an error message. This is when the string does not start with /
+if [[ ! $apps = '/'* ]]
+then
+	echo $apps
+	echo "Script read-config.php returned no usable app path"
+	exit
+fi
 
 if clone_example_theme "$app_name" "$apps" 
 then
   # Remove the default signature, which will cause a code integrity violation
   [ -f "$apps/$app_name/appinfo/signature.json" ] && rm "$apps/$app_name/appinfo/signature.json"
 
-  # Replace the default id
-  echo 
-  echo "- Updating theme id"
+  # Replace the default theme id / theme name
+  echo "Updating theme id / theme name"
   sed -i "s#<id>theme-example<#<id>$app_name<#" "$apps/$app_name/appinfo/info.xml"
 
   # Set the appropriate permissions
-  echo "- Setting theme file permissions"
+  echo "Setting new theme file permissions"
   chown -R www-data:www-data "$apps/$app_name"
 
-  # Enable the theme (app)
-  echo "- Enabling theme"
-  php "$owncloud_directory/occ" app:enable "$app_name"
+  # Enable the new theme app
+  if [ -e "$owncloud_root/occ" ]
+  then
+    echo "Enabling new theme in ownCloud"
+    php "$owncloud_root/occ" app:enable "$app_name"
+  else
+    echo
+    echo "occ command not found, please enable the app manually"
+  fi
 
   echo
   echo "Finished bootstrapping the new theme."
-
-  cd "$OLDPWD" || return
 fi


### PR DESCRIPTION
This is an improvement of the existing scripts for downloading the theme-example.
Referencing merged PR https://github.com/owncloud/documentation/pull/4281 (Added theme example download)
Note: the existing scripts do not work properly...

read-config.php
- [x]  can run stand alone and checks many important cases to be fail safe
- [x] reports meaningful error messages to highight the causing problem
- [x] returns either a full path of the app directory to be used or an error message

theme-bootstrap.sh
- [x] also got many checks and improvements to catch bad situations
- [x] reports meaningful error messages to highight the causing problem
- [x] does not continue when read-config.php returns an error
