### PR TITLE
webdav URL change

### DIFF
--- a/user_manual/files/access_webdav.rst
+++ b/user_manual/files/access_webdav.rst
@@ -341,7 +341,7 @@ ownCloud provides the possibility to access public shares over WebDAV.
 
 To access the public share, open::
 
-  https://example.com/owncloud/public.php/dav
+  https://example.com/owncloud/public.php/webdav
 
 in a WebDAV client, use the share token as username and the (optional) share password
 as password.


### PR DESCRIPTION
@cdamken noticed that the URL for Accessing public shares over WebDAV was not correct. This is the fix

changed dav to webdav