### PR TITLE
Update index.rst for occ_apps_command + improve doc headline of config_sample_php_parameters.rst

### DIFF
--- a/admin_manual/configuration/server/config_sample_php_parameters.rst
+++ b/admin_manual/configuration/server/config_sample_php_parameters.rst
@@ -1,6 +1,6 @@
-=====================
-Config.php Parameters
-=====================
+==========================
+Core Config.php Parameters
+==========================
 
 ownCloud uses the ``config/config.php`` file to control server operations.
 ``config/config.sample.php`` lists all the configurable parameters within

--- a/admin_manual/configuration/server/index.rst
+++ b/admin_manual/configuration/server/index.rst
@@ -8,6 +8,7 @@ Server Configuration
    security_setup_warnings
    import_ssl_cert
    occ_command
+   occ_apps_command
    activity_configuration
    antivirus_configuration
    caching_configuration


### PR DESCRIPTION
Added ``occ_apps_command`` to index.rst
The file is already present...

Improved the headline of ``config_sample_php_parameters.rst``
``Config.php Parameters`` --> ``Core Config.php Parameters``
In preperation for the upcoming ``config_sample_apps_php_parameters.rst`` file