### PR TITLE
Example code fixes to unused stuff

### DIFF
--- a/developer_manual/examples/php/vendor/guzzlehttp/guzzle/src/Handler/CurlHandler.php
+++ b/developer_manual/examples/php/vendor/guzzlehttp/guzzle/src/Handler/CurlHandler.php
@@ -1,7 +1,6 @@
 <?php
 namespace GuzzleHttp\Handler;
 
-use GuzzleHttp\Psr7;
 use Psr\Http\Message\RequestInterface;
 
 /**

--- a/developer_manual/examples/php/vendor/guzzlehttp/guzzle/src/Handler/CurlMultiHandler.php
+++ b/developer_manual/examples/php/vendor/guzzlehttp/guzzle/src/Handler/CurlMultiHandler.php
@@ -3,7 +3,6 @@ namespace GuzzleHttp\Handler;
 
 use GuzzleHttp\Promise as P;
 use GuzzleHttp\Promise\Promise;
-use GuzzleHttp\Psr7;
 use Psr\Http\Message\RequestInterface;
 
 /**

--- a/developer_manual/examples/php/vendor/guzzlehttp/guzzle/src/Middleware.php
+++ b/developer_manual/examples/php/vendor/guzzlehttp/guzzle/src/Middleware.php
@@ -4,7 +4,6 @@ namespace GuzzleHttp;
 use GuzzleHttp\Cookie\CookieJarInterface;
 use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Promise\RejectedPromise;
-use GuzzleHttp\Psr7;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Log\LoggerInterface;
 use Psr\Log\LogLevel;

--- a/developer_manual/examples/php/vendor/guzzlehttp/guzzle/src/RetryMiddleware.php
+++ b/developer_manual/examples/php/vendor/guzzlehttp/guzzle/src/RetryMiddleware.php
@@ -3,7 +3,6 @@ namespace GuzzleHttp;
 
 use GuzzleHttp\Promise\PromiseInterface;
 use GuzzleHttp\Promise\RejectedPromise;
-use GuzzleHttp\Psr7;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 

--- a/developer_manual/examples/php/vendor/guzzlehttp/promises/tests/EachPromiseTest.php
+++ b/developer_manual/examples/php/vendor/guzzlehttp/promises/tests/EachPromiseTest.php
@@ -163,7 +163,7 @@ class EachPromiseTest extends \PHPUnit_Framework_TestCase
     public function testFulfillsImmediatelyWhenGivenAnEmptyIterator()
     {
         $each = new EachPromise(new \ArrayIterator([]));
-        $result = $each->promise()->wait();
+        $each->promise()->wait();
     }
 
     public function testDoesNotBlowStackWithFulfilledPromises()

--- a/developer_manual/examples/php/vendor/guzzlehttp/psr7/tests/UploadedFileTest.php
+++ b/developer_manual/examples/php/vendor/guzzlehttp/psr7/tests/UploadedFileTest.php
@@ -262,7 +262,7 @@ class UploadedFileTest extends \PHPUnit_Framework_TestCase
     {
         $uploadedFile = new UploadedFile('not ok', 0, $status);
         $this->setExpectedException('RuntimeException', 'upload error');
-        $stream = $uploadedFile->getStream();
+        $uploadedFile->getStream();
     }
 
     public function testMoveToCreatesStreamIfOnlyAFilenameWasProvided()

--- a/developer_manual/examples/storage-backend/OCA/MyStorageApp/Storage/MyStorage.php
+++ b/developer_manual/examples/storage-backend/OCA/MyStorageApp/Storage/MyStorage.php
@@ -150,7 +150,7 @@ class MyStorage extends StorageAdapter {
 
 				// this wrapper will call the callback whenever fclose() was called on the file,
 				// after which we send the file to the library
-				$result = CallbackWrapper::wrap(
+				CallbackWrapper::wrap(
 					$source,
 					null,
 					null,


### PR DESCRIPTION
When in the documentation repo, my IDE wants to shout at me about these.
I guess that examples should not have unused includes and variables?

Note: there are also a bunch of "unusued parameter" and "unused private method" warnings. But maybe a lot of those are just because the examples are not complete. Or are the examples supposed to be complete?