### PR TITLE
Make it Clear That read-config.php is Listed Below theme-bootstrap.sh

### DIFF
--- a/developer_manual/core/theming.rst
+++ b/developer_manual/core/theming.rst
@@ -23,8 +23,14 @@ For example:
 
      theme-bootstrap.sh mynewtheme /var/www/owncloud
 
+theme-bootstrap.sh
+~~~~~~~~~~~~~~~~~~
+
 .. literalinclude:: ../scripts/theme-bootstrap.sh
    :language: bash
+
+read-config.php
+~~~~~~~~~~~~~~~
 
 .. literalinclude:: ../scripts/read-config.php
    :language: php


### PR DESCRIPTION
Thanks to @voroyam for pointing out that it's not necessarily clear that read-config.php is listed below theme-bootstrap.sh. For some reason, the script's also not rendering either. This PR should correct that.