### PR TITLE
Remove sudo www-data from acceptance test instructions

### DIFF
--- a/developer_manual/core/acceptance-tests.rst
+++ b/developer_manual/core/acceptance-tests.rst
@@ -225,8 +225,8 @@ Run a command like the following:
 
 .. code-block:: bash
 
-  sudo -u www-data make test-acceptance-api BEHAT_SUITE=apiTags
-  sudo -u www-data make test-acceptance-cli BEHAT_SUITE=cliProvisioning
+  make test-acceptance-api BEHAT_SUITE=apiTags
+  make test-acceptance-cli BEHAT_SUITE=cliProvisioning
 
 Running Acceptance Tests for a Feature
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -235,8 +235,8 @@ Run a command like the following:
 
 .. code-block:: bash
 
-  sudo -u www-data make test-acceptance-api BEHAT_FEATURE=tests/acceptance/features/apiTags/createTags.feature
-  sudo -u www-data make test-acceptance-cli BEHAT_FEATURE=tests/acceptance/features/cliProvisioning/addUser.feature
+  make test-acceptance-api BEHAT_FEATURE=tests/acceptance/features/apiTags/createTags.feature
+  make test-acceptance-cli BEHAT_FEATURE=tests/acceptance/features/cliProvisioning/addUser.feature
 
 Running Acceptance Tests for a Tag
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -246,8 +246,8 @@ To run test scenarios with a particular tag:
 
 .. code-block:: bash
 
-  sudo -u www-data make test-acceptance-api BEHAT_SUITE=apiTags BEHAT_FILTER_TAGS=@skip
-  sudo -u www-data make test-acceptance-cli BEHAT_SUITE=cliProvisioning BEHAT_FILTER_TAGS=@skip
+  make test-acceptance-api BEHAT_SUITE=apiTags BEHAT_FILTER_TAGS=@skip
+  make test-acceptance-cli BEHAT_SUITE=cliProvisioning BEHAT_FILTER_TAGS=@skip
 
 Displaying the ownCloud Log
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -256,7 +256,7 @@ It can be useful to see the tail of the ownCloud log when the test run ends. To 
 
 .. code-block:: bash
 
-  sudo -u www-data make test-acceptance-api BEHAT_SUITE=apiTags SHOW_OC_LOGS=true
+  make test-acceptance-api BEHAT_SUITE=apiTags SHOW_OC_LOGS=true
 
 Optional Environment Variables
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -265,13 +265,13 @@ If you want to use an alternative home name using the ``env`` variable add to th
 
 ::
 
-  sudo -u www-data make test-acceptance-api BEHAT_SUITE=apiTags OC_TEST_ALT_HOME=1
+  make test-acceptance-api BEHAT_SUITE=apiTags OC_TEST_ALT_HOME=1
 
 If you want to have encryption enabled add ``OC_TEST_ENCRYPTION_ENABLED=1``, as in the following example:
 
 ::
 
-  sudo -u www-data make test-acceptance-api BEHAT_SUITE=apiTags OC_TEST_ENCRYPTION_ENABLED=1
+  make test-acceptance-api BEHAT_SUITE=apiTags OC_TEST_ENCRYPTION_ENABLED=1
 
 For more information on Behat, and how to write acceptance tests using it, check out `the online documentation`_.
 

--- a/developer_manual/core/ui-testing.rst
+++ b/developer_manual/core/ui-testing.rst
@@ -103,9 +103,6 @@ Set Up Test
 
   The names of suites are found in the ``tests/acceptance/config/behat.yml`` file, and start with ``webUI``.
 
-  The tests may need to be run as the same user who is running the webserver and this user must also be the owner of the config file (``config/config.php``).
-  To run the tests as a user that is different to your current terminal user run ``sudo -E -u <username>``. For example, to execute the script as as ``www-data``, run ``sudo -E -u www-data make test-acceptance-webui BEHAT_SUITE=webUILogin``.
-
 - The browser for the tests runs inside the Selenium docker container. View it by running the ``vnc`` viewer:
 
   .. code-block:: console


### PR DESCRIPTION
Acceptance tests should be able to be run more independently of the system-under-test.
In particular, there should be no need to switch to being the Apache server user name.

See https://github.com/owncloud/docs/pull/247 for the same change in the docs repo.